### PR TITLE
Ignoring "Go To Board" link when using tab in Time Entry form

### DIFF
--- a/app/views/time_entries/_form_project_dependent_fields.html.erb
+++ b/app/views/time_entries/_form_project_dependent_fields.html.erb
@@ -11,7 +11,7 @@
 
       <% if time_entry.project.present? %>
 
-        <%= link_to visualization_path(time_entry.project.default_visualization), class: "link-primary text-xs", data: { turbo_frame: "_top" } do %>
+        <%= link_to visualization_path(time_entry.project.default_visualization), class: "link-primary text-xs", tabindex: '-1', data: { turbo_frame: "_top" } do %>
           <span class=" mr-2"><%= icon_for(:project_issues) %></span>
           <%= t("actions.go_to_board") %>
         <% end %>


### PR DESCRIPTION
When creating a new time entry, selecting a project and pressing TAB the focus will go to the next input and not the Go To Board link. 

![image](https://github.com/user-attachments/assets/20eedd7a-d2e7-4dd3-8531-513dc893c424)
