### PR TITLE
feat(boards): UI/UX enhancements for creating new columns and cards

### DIFF
--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -1,5 +1,6 @@
 class VisualizationsController < ApplicationController
   def show
     @visualization = Visualization.includes(groupings: :issues).find(params[:id])
+    skip_layout_content_wrapper!
   end
 end

--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -9,6 +9,27 @@ export default class extends Controller {
     "inlineCardFormTitle"
   ]
 
+  static values = {
+    scrollToOnConnect: Boolean
+  }
+
+  connect() {
+    if (this.scrollToOnConnectValue) {
+      let board = this.element.parentNode
+      const maxScrollX = board.scrollWidth - board.clientWidth;
+
+      board.scrollTo({
+        top: 0,
+        left: maxScrollX,
+        behavior: "instant"
+      });
+
+      // Without this, if we create and move the column after
+      // it will cause buggy scroll with sortablejs
+      this.scrollToOnConnectValue = false
+    }
+  }
+
   showInlineCardForm() {
     this.inlineCardFormTarget.classList.remove('hidden')
     this.showFormButtonTarget.classList.add('hidden')

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,5 +1,5 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
-<li class="w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
+<li class="max-h-full overflow-y-auto sm:first:ml-12 w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
   style="animation-duration: 240ms;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
@@ -64,15 +64,16 @@
     <% end %>
   </ul>
 
-  <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping: } %>
-  <button class="cpy-inline-create-button group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
-    data-grouping-column-target="showFormButton"
-    data-action="click->grouping-column#showInlineCardForm">
-    <i class="fa-solid fa-plus mr-2"></i>
-    <p class="grow text-left">
-      <%= t('visualizations.column_menu.create_issue') %>
-    </p>
-    <span class="group-hover:flex hidden text-xs font-medium ml-2 mr-2"><%= t("actions.press") %> N</span>
-  </button>
-
+  <div class="sticky bottom-0">
+    <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping: } %>
+    <button class="cpy-inline-create-button group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
+      data-grouping-column-target="showFormButton"
+      data-action="click->grouping-column#showInlineCardForm">
+      <i class="fa-solid fa-plus mr-2"></i>
+      <p class="grow text-left">
+        <%= t('visualizations.column_menu.create_issue') %>
+      </p>
+      <span class="group-hover:flex hidden text-xs font-medium ml-2 mr-2"><%= t("actions.press") %> N</span>
+    </button>
+  </div>
 </li>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,6 +1,10 @@
-<li class="w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container"
+<% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
+<li class="w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
+  style="animation-duration: 240ms;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
+  data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
+
   data-action="keypress.n@window->grouping-column#nWasPressed"
   >
   <header class="flex flex-row flex-nowrap gap-x-1 mb-4 px-2 relative" data-controller="dropdown">

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,5 +1,5 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
-<li class="max-h-full overflow-y-auto sm:first:ml-12 w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
+<li class="max-h-full w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
   style="animation-duration: 240ms;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
@@ -64,9 +64,9 @@
     <% end %>
   </ul>
 
-  <div class="sticky bottom-0">
+  <div class="sticky bottom-0 w-full">
     <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping: } %>
-    <button class="cpy-inline-create-button group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
+    <button class="cpy-inline-create-button w-full group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
       data-grouping-column-target="showFormButton"
       data-action="click->grouping-column#showInlineCardForm">
       <i class="fa-solid fa-plus mr-2"></i>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,4 +1,4 @@
-<li class="w-64 max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container"
+<li class="w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
   data-action="keypress.n@window->grouping-column#nWasPressed"
@@ -70,4 +70,5 @@
     </p>
     <span class="group-hover:flex hidden text-xs font-medium ml-2 mr-2"><%= t("actions.press") %> N</span>
   </button>
+
 </li>

--- a/app/views/visualizations/groupings/create.turbo_stream.erb
+++ b/app/views/visualizations/groupings/create.turbo_stream.erb
@@ -1,5 +1,5 @@
 <% if @grouping.persisted? %>
-  <%= turbo_stream.before 'js-create-new-column', partial: "visualizations/column", locals: { grouping: @grouping } %>
+  <%= turbo_stream.before 'js-create-new-column', partial: "visualizations/column", locals: { grouping: @grouping, recently_created: true } %>
   <%= turbo_stream.update 'grouping_form', "" %>
   <%= new_turbo_stream_alert_message(:success, t_flash_message(@grouping)) %>
 <% else %>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -1,11 +1,12 @@
 <div class="flex flex-col h-full">
-  <div class="flex flex-col sm:flex-row items-stretch justify-between gap-3 mb-6">
+  <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6">
     <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
       <%= @visualization.project.name %> - <%= Visualization.model_name.human(count: 1) %>
     </h2>
-    <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "btn-secondary", data: { turbo_frame: "_top" } do %>
-      <span class=" mr-2"><%= icon_for(:time_entries) %></span>
-      <%= t("actions.go_to_time_tracking") %>
+
+    <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "link-secondary group flex p-4", data: { turbo_frame: "_top" } do %>
+      <span class="text-lg mr-2"><%= icon_for(:time_entries) %></span>
+      <span class="group-hover:block sm:block md:hidden"><%= t("actions.go_to_time_tracking") %></span>
     <% end %>
   </div>
 
@@ -14,7 +15,7 @@
 
   <div class="relative grow cpy-columns-wrapper">
     <ul
-        class="grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
+        class="min-h-full grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
         data-controller="sortable"
         data-sortable-target="container"
         data-sortable-ignore-drag-selector-value=".js-no-column-drag"

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -1,4 +1,4 @@
-<main class="grow mb-12">
+<main class="grow">
   <div class="flex flex-col h-full">
     <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6 p-4 sm:px-12 pt-12">
       <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
@@ -26,7 +26,7 @@
 
     <div class="relative grow cpy-columns-wrapper">
       <ul
-          class="min-h-full max-h-full grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
+          class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:pl-12 sm:pr-12 sm:pb-4 sm:scroll-pr-12 flex flex-row flex-nowrap gap-x-8 pb-2 sm:px-12 items-start overflow-x-auto overflow-y-hidden scroll-smoot"
           data-controller="sortable"
           data-sortable-target="container"
           data-sortable-ignore-drag-selector-value=".js-no-column-drag"
@@ -34,7 +34,7 @@
           >
         <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping %>
 
-        <li class="order-last sm:mr-12 w-64 shrink-0" id="js-create-new-column">
+        <li class="order-last w-64 shrink-0" id="js-create-new-column">
           <%= link_to new_visualization_grouping_path(@visualization), class: "flex p-2 border items-center justify-between bg-body-contrast border-body-contrast-500 hover:border-primary-800 rounded-md shadow-xs text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
 
             <h2 class="grow font-semibold truncate">

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -14,7 +14,7 @@
 
   <div class="relative grow cpy-columns-wrapper">
     <ul
-        class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:-left-12 sm:-right-12 sm:-bottom-12 sm:scroll-pl-12 grid gap-x-8 justify-start grid-flow-col pb-2 sm:px-12 items-start overflow-x-auto overflow-y-hidden scroll-smooth"
+        class="grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
         data-controller="sortable"
         data-sortable-target="container"
         data-sortable-ignore-drag-selector-value=".js-no-column-drag"
@@ -22,14 +22,14 @@
         >
       <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping %>
 
-      <li class="order-last w-64 shrink-0" id="js-create-new-column">
-        <%= link_to new_visualization_grouping_path(@visualization), class: "border text-primary-400 bg-primary-50 border border-primary-100  hover:text-primary-500 hover:border-primary-100 hover:bg-primary-100 rounded-md shadow-xs p-2 shrink-0 mx-2 flex flex-col max-h-full", data: { turbo_frame: 'grouping_form' } do %>
-          <div class="flex items-center justify-between">
-            <h2 class="grow font-semibold truncate">
-              <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
-            </h2>
-            <i class="fa-solid fa-plus"></i>
-          </div>
+      <li class="order-last w-64 shrink-0 sticky right-0" id="js-create-new-column">
+        <%= link_to new_visualization_grouping_path(@visualization), class: "flex p-2 border items-center justify-between bg-body-contrast border-body-contrast-500 hover:border-primary-800 rounded-md shadow-xs text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
+
+          <h2 class="grow font-semibold truncate">
+            <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
+          </h2>
+          <i class="fa-solid fa-plus"></i>
+
         <% end %>
       </li>
 

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -1,40 +1,52 @@
-<div class="flex flex-col h-full">
-  <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6">
-    <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
-      <%= @visualization.project.name %> - <%= Visualization.model_name.human(count: 1) %>
-    </h2>
+<main class="grow mb-12">
+  <div class="flex flex-col h-full">
+    <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6 p-4 sm:px-12 pt-12">
+      <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
+        <%= @visualization.project.name %> - <%= Visualization.model_name.human(count: 1) %>
+      </h2>
 
-    <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "link-secondary group flex p-4", data: { turbo_frame: "_top" } do %>
-      <span class="text-lg mr-2"><%= icon_for(:time_entries) %></span>
-      <span class="group-hover:block sm:block md:hidden"><%= t("actions.go_to_time_tracking") %></span>
-    <% end %>
-  </div>
-
-  <%= turbo_frame_tag('grouping_form') {} %>
-  <%= turbo_frame_tag('issue_form') {} %>
-
-  <div class="relative grow cpy-columns-wrapper">
-    <ul
-        class="min-h-full grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
-        data-controller="sortable"
-        data-sortable-target="container"
-        data-sortable-ignore-drag-selector-value=".js-no-column-drag"
-        data-sortable-move-path-value="<%= move_visualization_groupings_path(@visualization) %>"
-        >
-      <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping %>
-
-      <li class="order-last w-64 shrink-0 sticky right-0" id="js-create-new-column">
-        <%= link_to new_visualization_grouping_path(@visualization), class: "flex p-2 border items-center justify-between bg-body-contrast border-body-contrast-500 hover:border-primary-800 rounded-md shadow-xs text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
+      <div class="flex items-stretch flex-col sm:flex-row gap-4">
+        <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "flex items-center link-secondary flex p-4", data: { turbo_frame: "_top" } do %>
+          <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
+          <span class="sm:block"><%= t("actions.go_to_time_tracking") %></span>
+        <% end %>
+        <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-primary", data: { turbo_frame: 'grouping_form' } do %>
+          <i class="fa-solid fa-plus mr-2"></i>
 
           <h2 class="grow font-semibold truncate">
             <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
           </h2>
-          <i class="fa-solid fa-plus"></i>
 
         <% end %>
-      </li>
+      </div>
+    </div>
 
-    </ul>
+    <%= turbo_frame_tag('grouping_form') {} %>
+    <%= turbo_frame_tag('issue_form') {} %>
+
+    <div class="relative grow cpy-columns-wrapper">
+      <ul
+          class="min-h-full max-h-full grid gap-x-8 justify-start grid-flow-col pb-2 items-start overflow-auto scroll-smooth"
+          data-controller="sortable"
+          data-sortable-target="container"
+          data-sortable-ignore-drag-selector-value=".js-no-column-drag"
+          data-sortable-move-path-value="<%= move_visualization_groupings_path(@visualization) %>"
+          >
+        <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping %>
+
+        <li class="order-last sm:mr-12 w-64 shrink-0" id="js-create-new-column">
+          <%= link_to new_visualization_grouping_path(@visualization), class: "flex p-2 border items-center justify-between bg-body-contrast border-body-contrast-500 hover:border-primary-800 rounded-md shadow-xs text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
+
+            <h2 class="grow font-semibold truncate">
+              <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
+            </h2>
+            <i class="fa-solid fa-plus"></i>
+
+          <% end %>
+        </li>
+
+      </ul>
+    </div>
+
   </div>
-
-</div>
+</main>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -14,7 +14,7 @@
 
   <div class="relative grow cpy-columns-wrapper">
     <ul
-        class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:-left-12 sm:-right-12 sm:-bottom-12 sm:scroll-pl-12 flex flex-row flex-nowrap gap-x-8 pb-2 sm:px-12 items-start overflow-x-auto overflow-y-hidden scroll-smooth"
+        class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:-left-12 sm:-right-12 sm:-bottom-12 sm:scroll-pl-12 grid gap-x-8 justify-start grid-flow-col pb-2 sm:px-12 items-start overflow-x-auto overflow-y-hidden scroll-smooth"
         data-controller="sortable"
         data-sortable-target="container"
         data-sortable-ignore-drag-selector-value=".js-no-column-drag"


### PR DESCRIPTION
This PR implements:

- A new "Create Column" fixed on top of the board
- After a new column is created it scrolls to the newly created column
- The newly created column appears with an animation
- The board CSS implementation was refactored to use css grid instead of flexbox. This will be more flexible in the future if we want to show columns in different ways (different sizes and using rows)

![new-button](https://github.com/user-attachments/assets/3da50694-30b1-49cc-8d94-9f4c891f2a96)
![new-column](https://github.com/user-attachments/assets/cc7fbbbf-55f2-45c0-b89e-392099ff66ea)

