### PR TITLE
feat: Implements optional http basic auth

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,5 +2,13 @@
 
 require_relative "config/environment"
 
+require 'rack/auth/basic'
+
+if ENV["HTTP_AUTH_USER"].present? && ENV["HTTP_AUTH_PASSWORD"].present?
+  use Rack::Auth::Basic, "Restricted Area" do |username, password|
+    username == ENV["HTTP_AUTH_USER"] && password == ENV["HTTP_AUTH_PASSWORD"]
+  end
+end
+
 run Rails.application
 Rails.application.load_server


### PR DESCRIPTION
# Why
This is worth doing because in some cases the user may want to expose the service to the internet and the reverse proxy used doesn't provide a quick/easy way to enable HTTP BASIC AUTH.

# How to use
The server automatically uses HTTP BASIC AUTH if these 2 environments variables are set:

- `HTTP_AUTH_USER` - For the username 
- `HTTP_AUTH_PASSWORD` - For the password