### PR TITLE
feat(TimeEntry/Form): submit via keyboard shortcuts

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -5,6 +5,8 @@ export default class extends Controller {
   }
 
   submit() {
-    this.element.submit()
+    // Should use the polyfill
+    // https://github.com/hotwired/turbo/pull/439
+    this.element.requestSubmit()
   }
 }

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -15,7 +15,7 @@
   <div class="">
     <%= form_with(model: time_entry, html: {
         class: 'flex flex-col gap-4',
-        data: { controller: 'dependent-fields' }
+        data: { controller: 'dependent-fields form' }
       }) do |f| %>
       <% if time_entry.errors.any? %>
         <div class="flex rounded-md w-full border-l-6 border-alert bg-alert bg-opacity-[15%] px-4 py-1 mb-5 shadow-sm md:p-4 text-sm text-alert">
@@ -45,8 +45,12 @@
 
           <%= f.text_area :description,
             class: "text-sm p-2 input-primary absolute w-full left-0 top-0 right-0 bottom-0 overflow-y-hidden",
-            "data-resizable-input-target": "input"
+            "data-resizable-input-target": "input",
+            "data-action": "keydown.ctrl+enter->form#submit keydown.meta+enter->form#submit"
             %>
+        </div>
+        <div class="text-right text-xs text-italic text-readable-content-500">
+          <span><%= t('.save_on_command_enter') %></span>
         </div>
       </div>
 

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -29,6 +29,8 @@ en:
     update:
       success: 'Profile succesfully updated.'
   time_entries:
+    form:
+      save_on_command_enter: press (CTRL + Enter) or (CMD + Enter) to save
     form_project_dependent_fields:
       select_a_project: "Select a project"
       project_has_no_issue: "There are no active issues for this project"

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -29,6 +29,8 @@ pt-BR:
       create_issue: 'Criar issue'
       destroy_confirmation: 'Tem certeza que quer deletar a coluna "%{title}"? Isso vai deletar todos as issues da coluna!'
   time_entries:
+    form:
+      save_on_command_enter: Pressione (CTRL + Enter) ou (CMD + Enter) para salvar
     form_project_dependent_fields:
       select_a_project: "Selecione um projeto primeiro"
       project_has_no_issue: "Este projeto não possui nenhuma issue ativa"


### PR DESCRIPTION
# Why
If we want to start/edit a new time entry with a description it's quicker to hit CMD+Enter/CTRL+Enter than pressing tab or clicking on the create/update button.

![cmd-enter](https://github.com/user-attachments/assets/b3b6527c-f647-4a0d-991b-7bedef44e3fa)

# Notes
This also changes the `form_controller.js` `FormController#submit` method to use the `requestSubmit()` polyfill to submit the form via JS.

https://github.com/hotwired/turbo/pull/439