### PR TITLE
fix(boards): updating card html after position changes

### DIFF
--- a/app/controllers/visualizations/allocations_controller.rb
+++ b/app/controllers/visualizations/allocations_controller.rb
@@ -1,8 +1,9 @@
 class Visualizations::AllocationsController < ApplicationController
   def move
     @allocation = GroupingIssueAllocation.find_by(grouping_id: move_params[:from][:group], position: move_params[:from][:position])
-
     @allocation.update(grouping_id: move_params[:to][:group], position: move_params[:to][:position])
+    @grouping = @allocation.grouping
+    @issue = @allocation.issue
   end
 
   private

--- a/app/javascript/controllers/sortable_controller.js
+++ b/app/javascript/controllers/sortable_controller.js
@@ -41,6 +41,9 @@ export default class extends Controller {
 
   _performMoveRequest(evt) {
     const request = new FetchRequest('post', this.movePathValue, {
+      headers: {
+        "Accept": "text/vnd.turbo-stream.html", // Tell the server to respond with Turbo Stream
+      },
       body: JSON.stringify({
         from: {
           group: evt.from.dataset.sortableGroupingId,

--- a/app/views/visualizations/allocations/move.turbo_stream.erb
+++ b/app/views/visualizations/allocations/move.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.replace dom_id(@issue), partial: "visualizations/card", locals: { grouping: @grouping, issue: @issue } %>

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -307,22 +307,23 @@ describe 'As a user, I want to manage my project kanban visualization' do
     third_issue = all_cards[2]
 
     first_issue.drag_to(third_issue)
-    second_issue.drag_to(first_issue)
 
-    changes_issues = all(".cpy-card")
+    # We need this to make capybara wait for the
+    # turbo-stream response to finish
+    expect(page).to have_content("Issue 1")
 
-    first_issue = changes_issues[0]
-    second_issue = changes_issues[1]
-    third_issue = changes_issues[2]
+    # now that the turbo stream has finished we
+    # can get the cards with the new HTML for the moved on
+    all_cards = all(".cpy-card")
 
-    expect(first_issue).to have_content("Issue 2")
-    expect(second_issue).to have_content("Issue 0")
-    expect(third_issue).to have_content("Issue 1")
+    expect(all_cards[0].text).to eq("Issue 1")
+    expect(all_cards[1].text).to eq("Issue 2")
+    expect(all_cards[2].text).to eq("Issue 0")
 
     expect(grouping.allocations.map(&:issue).map(&:title)).to eq([
+      "Issue 1",
       "Issue 2",
-      "Issue 0",
-      "Issue 1"
+      "Issue 0"
     ])
   end
 


### PR DESCRIPTION
Before this change, the card HTML wasn't being updated so the card `<a>` link tag that points to it's detail form was still using the old group_id in the `href` attribute.

This caused a very nasty bug that you could reproduce by:

- Entering a board with multiple columns
- Move a card to another column
- Remove the old column
- Click in a card
- You will see a "Content missing" because Rails is responding with an error

The test was modified to fetch the new HTML element returned by the turbo_stream response. Otherwise capybara would show an error: stale element reference: stale element not found in the current frame

The route doesn't need to contain the grouping id so this will be refactored in the next PR. 

With the refactoring this fix isn't really necessary but it's still a good idea to update the card to ensure that nothing similar happens again when we add more information to the card UI (maybe something related to it's position in the board).