### PR TITLE
feat(Issues): Issue URL navigation 

### DIFF
--- a/app/controllers/visualizations/issues_controller.rb
+++ b/app/controllers/visualizations/issues_controller.rb
@@ -12,11 +12,6 @@ class Visualizations::IssuesController < ApplicationController
     end
   end
 
-  def edit
-    @issue = Issue.find(params[:id])
-    render partial: "form", locals: { visualization: current_visualization, issue: @issue  }
-  end
-
   def update
     @issue = Issue.find(params[:id])
     @updated = @issue.update(permitted_params)

--- a/app/controllers/visualizations/issues_controller.rb
+++ b/app/controllers/visualizations/issues_controller.rb
@@ -1,12 +1,6 @@
 class Visualizations::IssuesController < ApplicationController
   helper_method :current_visualization
 
-  def new
-    @issue = Issue.new
-
-    render partial: "form", locals: { visualization: current_visualization, issue: @issue  }
-  end
-
   def create
     @issue = Issue.new(permitted_params.merge(project_id: current_visualization.project.id))
     @grouping = Grouping.find params[:allocate_to_grouping_id]

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -1,6 +1,9 @@
 class VisualizationsController < ApplicationController
   def show
     @visualization = Visualization.includes(groupings: :issues).find(params[:id])
+    if params[:issue_id]
+      @open_issue = Issue.find(params[:issue_id])
+    end
     skip_layout_content_wrapper!
   end
 end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -28,6 +28,10 @@ class CustomModal extends Modal {
     }
   }
 
+  close(e) {
+    super.close(e)
+    this.dispatch("closed")
+  }
 }
 
 application.register('modal', CustomModal)

--- a/app/javascript/controllers/issue_detail_controller.js
+++ b/app/javascript/controllers/issue_detail_controller.js
@@ -13,7 +13,8 @@ export default class extends Controller {
   ]
 
   static values = {
-    attachPath: String
+    attachPath: String,
+    visualizationPath: String
   }
 
   connect() {
@@ -113,5 +114,18 @@ export default class extends Controller {
       button.querySelector(".fa-check").classList.add('hidden')
       button.querySelector(".fa-copy").classList.remove('hidden')
     }, 1500)
+  }
+
+  goBackHistory() {
+
+    Turbo.visit(this.visualizationPathValue, {
+      action: 'advance',
+      // Rendering in a frame prevents the page reloading
+      // This also keeps the restoration visits (back button)
+      // working. But if the user goes back to a state showing
+      // only the board the horizontal scroll is affected
+      // https://turbo.hotwired.dev/handbook/drive#restoration-visits
+      frame: 'issue_form'
+    })
   }
 }

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -1,7 +1,12 @@
 <li class="cpy-card"
   id="<%= dom_id(issue) %>"
   data-grouping-column-target="card">
-  <%= link_to edit_visualization_issue_path(visualization, issue), class: "group relative flex flex-col text-sm text-content-500 border-2 border-background-200 bg-background-50 hover:bg-background-100 hover:border-background-900 cursor-pointer shadow-sm rounded-xl card p-3", data: { turbo_frame: 'issue_form' } do %>
+  <%= link_to show_visualization_issue_path(visualization, issue),
+    class: "group relative flex flex-col text-sm text-content-500 border-2 border-background-200 bg-background-50 hover:bg-background-100 hover:border-background-900 cursor-pointer shadow-sm rounded-xl card p-3",
+    data: {
+      turbo_frame: 'issue_form',
+      turbo_action: 'advance'
+    } do %>
 
     <div class="hidden flex items-center justify-center p-2 text-xs flex group-hover:flex items-center absolute top-2 right-2 rounded-full  bg-background-50">
       <i class="fa fa-pencil"></i>

--- a/app/views/visualizations/issues/_form.html.erb
+++ b/app/views/visualizations/issues/_form.html.erb
@@ -3,6 +3,8 @@
     class: "max-h-screen w-full max-w-4xl relative cpy-issue-detail",
     data: {
       controller: "issue-detail",
+      action: "modal:closed@window->issue-detail#goBackHistory",
+      "issue-detail-visualization-path-value": visualization_path(visualization),
       "issue-detail-attach-path-value": attach_issue_file_path(issue)
     }}) do %>
     <div data-controller="dropzone" data-action="dropzone:complete->issue-detail#fileUploadCompleted">

--- a/app/views/visualizations/issues/_form.html.erb
+++ b/app/views/visualizations/issues/_form.html.erb
@@ -4,8 +4,7 @@
     data: {
       controller: "issue-detail",
       "issue-detail-attach-path-value": attach_issue_file_path(issue)
-    }
-  }) do %>
+    }}) do %>
     <div data-controller="dropzone" data-action="dropzone:complete->issue-detail#fileUploadCompleted">
       <div class="border-b border-background-200 pb-2 mb-4">
         <div class="flex items-center space-x-2">
@@ -75,7 +74,7 @@
               <%= f.button text, class: "btn-primary", value: "update-and-close-modal" %>
             </div>
           <% end %>
-          <%= render partial: 'files_drop', locals: { issue: } %>
+          <%= render partial: '/visualizations/issues/files_drop', locals: { issue: } %>
         </div>
         <% if issue.persisted? %>
           <div class="flex flex-col gap-2 text-sm font-medium text-readable-content-700 text-center">

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -24,7 +24,12 @@
     </div>
 
     <%= turbo_frame_tag('grouping_form') {} %>
-    <%= turbo_frame_tag('issue_form') {} %>
+
+    <% if @open_issue.present? %>
+      <%= render partial: 'visualizations/issues/form', locals: { issue: @open_issue, visualization: @visualization } %>
+    <% else %>
+      <%= turbo_frame_tag('issue_form') {} %>
+    <% end %>
 
     <div class="relative grow cpy-columns-wrapper">
       <ul

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :issues, only: [ :new, :create, :edit, :update, :destroy ]
+      resources :issues, only: [ :create, :edit, :update, :destroy ]
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,11 @@ Rails.application.routes.draw do
     get :total_time
   end
 
+  get "visualizations/:id/issues/:issue_id",
+      as: :show_visualization_issue,
+      controller: :visualizations,
+      action: :show
+
   resources :visualizations, only: :show do
     scope module: :visualizations do
       resources :groupings, only: [ :new, :create, :edit, :update, :destroy ] do
@@ -33,7 +38,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :issues, only: [ :create, :edit, :update, :destroy ]
+      resources :issues, only: [ :create, :update, :destroy ]
     end
   end
 


### PR DESCRIPTION
# Why
- We may want to favorite an Issue using the browser
- If more than one person is using the app it's very helpful to have a issue link to share
- This allows referencing issues inside another by writing the issue link in the description

# What has been done
- Issue now has a dedicated URL
- Opening an issue now advances the browser history
- Closing the issue modal advances the browser history to the `visualization/:id`

# Limitations
- The behavior of closing the issue modal with browser back history button scrolls the board to the first column. 