### PR TITLE
feat: Friendly Issue Urls

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -7,4 +7,8 @@ class Issue < ApplicationRecord
 
   # Validations
   validates :title, presence: true
+
+  def to_param
+    [ id, title.parameterize ].join("-")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,12 +25,12 @@ Rails.application.routes.draw do
     get :total_time
   end
 
-  get "visualizations/:id/issues/:issue_id",
+  get "v/:id/i/:issue_id",
       as: :show_visualization_issue,
       controller: :visualizations,
       action: :show
 
-  resources :visualizations, only: :show do
+  resources :visualizations, path: "v", only: :show do
     scope module: :visualizations do
       resources :groupings, only: [ :new, :create, :edit, :update, :destroy ] do
         collection do
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :issues, only: [ :create, :update, :destroy ]
+      resources :issues, path: "i", only: [ :create, :update, :destroy ]
     end
   end
 


### PR DESCRIPTION
# Why
- Using the issue title on the URL facilitates when we're sharing the link with someone
- Shorter urls makes it easier to read

![image](https://github.com/user-attachments/assets/a427a541-b5be-443a-9b2a-5c494a3075e3)
