### PR TITLE
feat: link to issue from time entries list + icons update

### DIFF
--- a/app/helpers/application_helper/icons.rb
+++ b/app/helpers/application_helper/icons.rb
@@ -4,12 +4,13 @@ module Icons
     icon_classes = case name.to_sym
     when :time_entries
       "fa-solid fa-clock"
-    when :project_issues
-      "fa-solid fa-list-check"
+
     when :groupings
       "fa-solid fa-table-columns"
+    when :boards
+      "fa-solid fa-chart-simple rotate-180"
     when :issues
-      "fa-solid fa-rectangle-list"
+      "fa-solid fa-check-double"
     when :projects
       "fa-solid fa-folder-closed"
     when :user

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -43,7 +43,7 @@
         <%= t("actions.go_to_time_tracking") %>
       <% end %>
       <%= link_to visualization_path(project.default_visualization), class: "btn-secondary py-4", data: { turbo_frame: "_top" } do %>
-        <span class=" mr-2"><%= icon_for(:project_issues) %></span>
+        <span class=" mr-2"><%= icon_for(:boards) %></span>
         <%= t("actions.go_to_board") %>
       <% end %>
     </div>

--- a/app/views/time_entries/_form_project_dependent_fields.html.erb
+++ b/app/views/time_entries/_form_project_dependent_fields.html.erb
@@ -12,7 +12,7 @@
       <% if time_entry.project.present? %>
 
         <%= link_to visualization_path(time_entry.project.default_visualization), class: "link-primary text-xs", tabindex: '-1', data: { turbo_frame: "_top" } do %>
-          <span class=" mr-2"><%= icon_for(:project_issues) %></span>
+          <span class=" mr-2"><%= icon_for(:issues) %></span>
           <%= t("actions.go_to_board") %>
         <% end %>
       <% end %>

--- a/app/views/time_entries/_time_entry.html.erb
+++ b/app/views/time_entries/_time_entry.html.erb
@@ -17,10 +17,16 @@
           <p class="text-sm italic text-readable-content-500">
             <%= time_entry.issue.title %>
           </p>
-        <% end %>
-        <%= link_to visualization_path(time_entry.project.default_visualization), class: "link-primary text-xs", data: { turbo_frame: "_top" } do %>
-          <span class=" mr-1"><%= icon_for(:project_issues) %></span>
-          <%= t("actions.go_to_board") %>
+
+          <%= link_to visualization_issue_path(time_entry.project.default_visualization, time_entry.issue), class: "flex items-center link-primary text-xs", data: { turbo_frame: "_top" } do %>
+            <span class="mr-1"><%= icon_for(:issues) %></span>
+            <%= t("actions.go_to_issue") %>
+          <% end %>
+        <% else %>
+          <%= link_to visualization_path(time_entry.project.default_visualization), class: "flex items-center link-primary text-xs", data: { turbo_frame: "_top" } do %>
+            <span class="mr-1"><%= icon_for(:boards) %></span>
+            <%= t("actions.go_to_board") %>
+          <% end %>
         <% end %>
 
       </div>

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -54,7 +54,8 @@ en:
     clear_filter: "clear filter"
     preview: "Preview"
     press: "Press"
-    go_to_board: 'Go to Board View'
+    go_to_board: 'Go to Board'
+    go_to_issue: 'Go to Issue'
     go_to_time_tracking: "Go to time tracking"
   flash:
     change_success: "Change successfully made."

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -56,6 +56,7 @@ pt-BR:
     preview: "Pré-visualização"
     press: "Pressione"
     go_to_board: 'Ir para visão de quadro'
+    go_to_issue: 'Ir para issue'
     go_to_time_tracking: "Ir para registro de tempo"
   flash:
     change_success: "Alteração feita com sucesso."


### PR DESCRIPTION
This PR: 

- Updates icons for boards and issues
- Add a link to the issue in the time entries list
- If the time entry has no issue a link to the board is shown instead

![time-entry-links](https://github.com/user-attachments/assets/9ed3051d-f488-466b-b1a9-a6f66e5d44b0)
