### PR TITLE
Chore: Setup Action Cable - First step for real-time app

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Channel < ActionCable::Channel::Base
+  end
+end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,4 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,3 +3,4 @@ import "@hotwired/turbo-rails"
 import "controllers"
 
 import "@fortawesome/fontawesome-free"
+import "channels"

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,1 @@
+// Import all the channels to be used by Action Cable

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= action_cable_meta_tag %>
 
     <%= yield :head %>
 

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,20 @@
+# Async adapter only works within the same process, so for manually triggering cable updates from a console,
+# and seeing results in the browser, you must do so from the web console (running inside the dev process),
+# not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
+# to make the web console appear.
+solid_cable_default: &solid_cable_default
+  adapter: solid_cable
+  connects_to:
+    database:
+      writing: cable
+  polling_interval: 0.1.seconds
+  message_retention: 1.day
+
 development:
-  adapter: async
+  <<: *solid_cable_default
 
 test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: eigenfocus_production
+  <<: *solid_cable_default

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -2,7 +2,7 @@
 # and seeing results in the browser, you must do so from the web console (running inside the dev process),
 # not a terminal started via bin/rails console! Add "console" to any action or any ERB template view
 # to make the web console appear.
-solid_cable_default: &solid_cable_default
+default: &default
   adapter: solid_cable
   connects_to:
     database:
@@ -11,10 +11,10 @@ solid_cable_default: &solid_cable_default
   message_retention: 1.day
 
 development:
-  <<: *solid_cable_default
+  <<: *default
 
 test:
   adapter: test
 
 production:
-  <<: *solid_cable_default
+  <<: *default

--- a/config/database.example.yml
+++ b/config/database.example.yml
@@ -10,8 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  <<: *default
-  database: storage/development.sqlite3
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  cable:
+    <<: *default
+    database: storage/development_cable.sqlite3
+    migrations_paths: db/cable_migrate
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
@@ -27,6 +32,10 @@ test:
 # Similarly, if you deploy your application as a Docker container, you must
 # ensure the database is located in a persisted volume.
 production:
-  <<: *default
-  database: app-data/database/production.sqlite3
-  # database: path/to/persistent/storage/production.sqlite3
+  primary:
+    <<: *default
+    database: app-data/database/production.sqlite3
+  cable:
+    <<: *default
+    database: app-data/database/production_cable.sqlite3
+    migrations_paths: db/cable_migrate

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -23,3 +23,5 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/javascript/controllers/visualizations", under: "controllers"
 pin "@rails/request.js", to: "@rails--request.js.js" # @0.0.11
 pin "marked" # @15.0.4
+pin "@rails/actioncable", to: "actioncable.esm.js"
+pin_all_from "app/javascript/channels", under: "channels"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
 
+  mount ActionCable.server => "/cable"
+
   resources :projects, except: [ :destroy ] do
     member do
       put :archive

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,0 +1,11 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", limit: 1024, null: false
+    t.binary "payload", limit: 536870912, null: false
+    t.datetime "created_at", null: false
+    t.integer "channel_hash", limit: 8, null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+end

--- a/db/cable_schema.rb
+++ b/db/cable_schema.rb
@@ -1,4 +1,16 @@
-ActiveRecord::Schema[7.1].define(version: 1) do
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 1) do
   create_table "solid_cable_messages", force: :cascade do |t|
     t.binary "channel", limit: 1024, null: false
     t.binary "payload", limit: 536870912, null: false

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -303,7 +303,6 @@ describe 'As a user, I want to manage my project kanban visualization' do
     all_cards = all(".cpy-card")
 
     first_issue = all_cards[0]
-    second_issue = all_cards[1]
     third_issue = all_cards[2]
 
     first_issue.drag_to(third_issue)


### PR DESCRIPTION
## Why?

While using Eigenfocus with more than one tab open at the same time is possible, it would be even better if some updates would reflect on already open pages.

This is specially true for pages like the board view and timesheet.

So this PR setup Action Cable, which enables WebSocket connections that we can use to solve the mentioned issue.

## How

- Add `SolidCable` to allow ActionCable use the SQLite database instead of adding something like Redis as a dependency
- Configure the cable database (Used by `SolidCable` adapter)
- Add basic setup for creating ActionCable channels