### PR TITLE
Chore: Setup random repeatable tests

### DIFF
--- a/spec/features/reports/time_report_spec.rb
+++ b/spec/features/reports/time_report_spec.rb
@@ -7,7 +7,7 @@ context "As a user, I want to generate time reports" do
     end
   end
 
-  let!(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user) }
 
   let(:project_alpha) { FactoryBot.create(:project, name: 'Alpha') }
   let(:project_beta) { FactoryBot.create(:project, name: 'Beta') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,9 +44,6 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -57,12 +54,12 @@ RSpec.configure do |config|
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
+  config.example_status_persistence_file_path = "tmp/tests.txt"
 
   # Limits the available syntax to the non-monkey patched syntax that is
   # recommended. For more details, see:
   # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
+  # config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an
@@ -77,7 +74,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10
+  # config.profile_examples = 10
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing
@@ -90,5 +87,4 @@ RSpec.configure do |config|
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
   Kernel.srand config.seed
-=end
 end


### PR DESCRIPTION
## Why?

During the last PR CI run, we notice that some tests fail without a reasonable explanation. However, we couldn't reproduce it (Neither local nor on CI).

So, assuming we can have other flaky tests, this PR setup tests to run in a random order.

Also, during this setup, one test fail and we could reproduce it, so it is already a win 🤷