### PR TITLE
Feat: Live updates on time tracking page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem "image_processing", "~> 1.13"
 
 gem "positioning", "~> 0.4"
 
+# Real-time updates
+gem "solid_cable", "~> 3.0"
+
 group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
   gem "brakeman", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    solid_cable (3.0.7)
+      actioncable (>= 7.2)
+      activejob (>= 7.2)
+      activerecord (>= 7.2)
+      railties (>= 7.2)
     sqlite3 (2.5.0-aarch64-linux-gnu)
     sqlite3 (2.5.0-aarch64-linux-musl)
     sqlite3 (2.5.0-arm-linux-gnu)
@@ -391,6 +396,7 @@ DEPENDENCIES
   rspec-rails (~> 7.1)
   rubocop-rails-omakase
   selenium-webdriver (= 4.27)
+  solid_cable (~> 3.0)
   sqlite3 (>= 2.1)
   stimulus-rails
   tailwindcss-ruby

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -28,9 +28,11 @@ class TimeEntriesController < ApplicationController
   def create
     @time_entry = current_user.time_entries.new(time_entry_params)
 
-    if @time_entry.save
+    if @time_entry.valid?
       if @time_entry.total_logged_time_in_minutes.zero?
         @time_entry.start!
+      else
+        @time_entry.save!
       end
 
       @total_logged_time = current_user.time_entries.by_date(@time_entry.reference_date).sum(:total_logged_time_in_minutes)

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -14,6 +14,9 @@ class TimeEntry < ApplicationRecord
             presence: true,
             numericality: { greater_than_or_equal_to: 0 }
 
+  # Broadcasts
+  broadcasts_to ->(time_entry) { "time_entries" }, inserts_by: :prepend, target: "time-entries-tbody"
+
   def start!
     fail "You can only start stopped time entries" if started_at.present?
     self.started_at = DateTime.current

--- a/app/views/time_entries/_time_entry.html.erb
+++ b/app/views/time_entries/_time_entry.html.erb
@@ -1,5 +1,5 @@
 <% running_class = time_entry.running? ? "border-secondary-500" : "border-background-100" %>
-<div id="<%= dom_id(time_entry) %>" class="<%= running_class %> transition-all bg-body-contrast relative rounded-md flex-col lg:flex-row gap-4 flex justify-stretch shadow-sm border ">
+<div id="<%= dom_id(time_entry) %>" class="<%= running_class %> transition-all bg-body-contrast relative rounded-md flex-col lg:flex-row gap-4 flex justify-stretch shadow-sm border peer peer-exists">
   <% if time_entry.running? %>
     <span class="absolute left-[-7px] flex" style="width:16px; height:16px; top: calc(50% - 6px)">
       <span class="relative  inline-flex rounded-full bg-body-contrast text-secondary-500" style="left:-2px;top:-2px;font-size:16px">

--- a/app/views/time_entries/create.turbo_stream.erb
+++ b/app/views/time_entries/create.turbo_stream.erb
@@ -1,7 +1,6 @@
 <% if @time_entry.persisted? %>
   <%= turbo_stream.prepend "time-entries-tbody", partial: "time_entries/time_entry", locals: { time_entry: @time_entry } %>
   <%= turbo_stream.update 'time_entry_form', "" %>
-  <%= turbo_stream.remove 'empty-row' %>
   <%= turbo_stream_update_daily_time(@time_entry.reference_date, @total_logged_time)%>
   <%= new_turbo_stream_alert_message(:notice, t_flash_message(@time_entry)) %>
 <% else %>

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -1,5 +1,7 @@
 <% set_page_title(:time_tracking) %>
 
+<%= turbo_stream_from :time_entries %>
+
 <% if params[:new_entry].present? %>
   <%
     new_entry = TimeEntry.new
@@ -85,20 +87,18 @@
 
 
 <div class="flex flex-col gap-4" id="time-entries-tbody">
-  <% if @time_entries.count.zero? %>
-    <div id="empty-row" class="card">
-      <p class='text-center text-readable-content-500'>
-        <%= t(".zero_records", date: l(@reference_date, format: :long )) %>
-      </p>
-      <p class="mt-3 text-center mb-4">
-        <%= link_to new_time_entry_path(reference_date: @reference_date), class: "btn-primary py-4 inline-block", data: { turbo_frame: 'time_entry_form' } do %>
-          <i class="fa-solid fa-circle-plus mr-1"></i>
-          <%= t('.click_here_to_create') %>
-        <% end %>
-      </p>
-    </tr>
-  <% else %>
-    <%= render partial: 'time_entry', collection: @time_entries, as: :time_entry %>
-  <% end %>
+  <%= render partial: 'time_entry', collection: @time_entries, as: :time_entry %>
+
+  <div id="empty-row" class="card peer-[.peer-exists]:hidden">
+    <p class='text-center text-readable-content-500'>
+      <%= t(".zero_records", date: l(@reference_date, format: :long )) %>
+    </p>
+    <p class="mt-3 text-center mb-4">
+      <%= link_to new_time_entry_path(reference_date: @reference_date), class: "btn-primary py-4 inline-block", data: { turbo_frame: 'time_entry_form' } do %>
+        <i class="fa-solid fa-circle-plus mr-1"></i>
+        <%= t('.click_here_to_create') %>
+      <% end %>
+    </p>
+  </tr>
 </div>
 <% end %>


### PR DESCRIPTION
## Why?

As explained [before](https://github.com/Eigenfocus/eigenfocus/pull/40), we are making the UX better by making pages update their content in real-time.

This PR adds this behavior on the Time Tracking page

## How

- Add missing SolidCable gem
- Add `broadcasts_to` to time entries model
- Change index "no time entry" panel to appear/disappear based on CSS sibling selector, instead of depend on HTML updates

## Preview

![Test](https://github.com/user-attachments/assets/8ef21942-2140-43c0-ac20-9e9b5f76c732)
