### PR TITLE
feat(Boards): issues filtering by title and labels

### DIFF
--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -9,6 +9,10 @@
   display: none;
 }
 
+[data-is-issue-search-match="false"] {
+  display: none;
+}
+
 .btn .loading-spinner,
 .btn-primary .loading-spinner,
 .btn-secondary .loading-spinner,

--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -122,12 +122,19 @@ input.input-primary,
   @apply w-full rounded-lg border border-background-300 px-3 bg-background-50 text-readable-content-500 py-2 placeholder:text-readable-content-400/70 hover:border-background-400 focus:border-primary-500;
 }
 
+
+.input-contrast,
+input.input-contrast,
+.flatpickr-input.input-contrast {
+  @apply w-full rounded-lg border border-background-300 px-3 bg-body-contrast text-readable-content-500 py-2 placeholder:text-readable-content-400/70 hover:border-background-400 focus:border-primary-500;
+}
+
 .input-with-icon-wrapper .icon-wrapper {
-  @apply text-readable-content-500;
+  @apply text-readable-content-400;
 }
 
 .input-sm {
-  @apply py-1;
+  @apply py-2 text-xs !important;
 }
 
 .label-primary {
@@ -142,6 +149,7 @@ input.input-primary,
   @apply absolute text-readable-content-500 inset-y-0 start-0 flex items-center ps-3 pointer-events-none;
 }
 
+.input-with-icon-wrapper input,
 .input-with-icon-wrapper input.input-primary {
   @apply ps-10;
 }

--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -4,6 +4,11 @@
 @import './sortablejs';
 @import './pagy.tailwind';
 
+/* :empty does't work if element has any text */
+.hide-if-empty:not(:has(:first-child)) {
+  display: none;
+}
+
 .btn .loading-spinner,
 .btn-primary .loading-spinner,
 .btn-secondary .loading-spinner,

--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -24,12 +24,12 @@
   @apply w-3 h-3 mr-2;
 }
 
-.btn-primary.btn-sm,
-.btn-secondary.btn-sm,
-.btn-tertiary.btn-sm,
-.btn-danger.btn-sm,
-.btn-cancel.btn-sm {
+.btn.btn-sm {
   @apply py-1 px-2 text-xs h-7;
+}
+
+.btn.btn-md {
+  @apply py-1 px-2 text-sm h-9;
 }
 
 .btn-primary.btn-xl,

--- a/app/helpers/application_helper/labels.rb
+++ b/app/helpers/application_helper/labels.rb
@@ -3,7 +3,10 @@ module ApplicationHelper
     def badge_for_label(label)
       options = {
         class: "inline-flex rounded-full border-readable-content-400 text-readable-content-400 border border py-1 px-2 text-xs font-medium",
-        style: ""
+        style: "",
+        "data": {
+          "issue-label": true
+        }
       }
 
       content_tag(:span, options) do

--- a/app/helpers/application_helper/labels.rb
+++ b/app/helpers/application_helper/labels.rb
@@ -2,15 +2,13 @@ module ApplicationHelper
   module Labels
     def badge_for_label(label)
       options = {
-        class: "inline-flex rounded-full border-#{color_for_label(label)} text-#{color_for_label(label)} border py-1 px-2 text-xs font-medium"
+        class: "inline-flex rounded-full border-readable-content-400 text-readable-content-400 border border py-1 px-2 text-xs font-medium",
+        style: ""
       }
 
       content_tag(:span, options) do
         label.title
       end
-    end
-
-    def color_for_label(label)
     end
   end
 end

--- a/app/javascript/controllers/visualization/issue_filtering_controller.js
+++ b/app/javascript/controllers/visualization/issue_filtering_controller.js
@@ -1,5 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
+// https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
+function normalizeText(text) {
+  return text
+    .toLowerCase()
+    .normalize("NFD")  // Decompose characters to their basic form
+    .replace(/[\u0300-\u036f]/g, "");  // Remove diacritical marks (accents)
+}
+
 export default class extends Controller {
   static targets = [
     "searchInput",
@@ -19,15 +27,16 @@ export default class extends Controller {
   }
 
   #matchesTitle(issue) {
-    const title = issue.querySelector("[data-issue-title]").textContent.toLowerCase()
+    const title = normalizeText(issue.querySelector("[data-issue-title]").textContent.toLowerCase())
     return title.includes(this.searchTerm)
   }
+
   #matchesLabels(issue) {
-    const labels = [...issue.querySelectorAll("[data-issue-label]")].map(label => label.textContent.toLowerCase())
+    const labels = [...issue.querySelectorAll("[data-issue-label]")].map(label => normalizeText(label.textContent.toLowerCase()))
     return labels.some(label => label.includes(this.searchTerm))
   }
 
   get searchTerm() {
-    return this.searchInputTarget.value.toLowerCase();
+    return normalizeText(this.searchInputTarget.value.toLowerCase());
   }
 }

--- a/app/javascript/controllers/visualization/issue_filtering_controller.js
+++ b/app/javascript/controllers/visualization/issue_filtering_controller.js
@@ -1,42 +1,74 @@
-import { Controller } from "@hotwired/stimulus";
+import { Controller } from "@hotwired/stimulus"
+import  Fuse  from 'fuse.js'
 
-// https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
-function normalizeText(text) {
-  return text
-    .toLowerCase()
-    .normalize("NFD")  // Decompose characters to their basic form
-    .replace(/[\u0300-\u036f]/g, "");  // Remove diacritical marks (accents)
+const fuseOptions = {
+  isCaseSensitive: false,
+  // includeScore: false,
+  // ignoreDiacritics: false,
+  // shouldSort: true,
+  // includeMatches: false,
+  findAllMatches: true, //show all matches
+  // minMatchCharLength: 1,
+  // location: 0,
+  threshold: 0.42,
+  // distance: 100,
+  // useExtendedSearch: false,
+  ignoreLocation: true, // matches anywhere
+  // ignoreFieldNorm: false,
+  // fieldNormWeight: 1,
+  keys: [
+    "title",
+    "labels"
+  ]
 }
 
 export default class extends Controller {
   static targets = [
     "searchInput",
     "issue"
-  ];
+  ]
+
+  initialize() {
+    this.fuse = new Fuse([], fuseOptions)
+  }
 
   filterIssues() {
-    this.issueTargets.forEach((issue) => {
-      const hasMatch = this.#matchesTitle(issue) || this.#matchesLabels(issue)
+    if (this.searchTerm === "") {
+      this.issueTargets.forEach(issue => (issue.style.display = "block"));
+      return;
+    }
 
-      if (hasMatch) {
-        issue.style.display = "block";
-      } else {
-        issue.style.display = "none";
-      }
-    })
+    const issuesMatches = this.fuse.search(this.searchTerm).map(result => result.item.issue)
+
+    this.issueTargets.forEach(issue => {
+      issue.style.display = issuesMatches.includes(issue) ? "block" : "none"
+    });
   }
 
-  #matchesTitle(issue) {
-    const title = normalizeText(issue.querySelector("[data-issue-title]").textContent.toLowerCase())
-    return title.includes(this.searchTerm)
-  }
-
-  #matchesLabels(issue) {
-    const labels = [...issue.querySelectorAll("[data-issue-label]")].map(label => normalizeText(label.textContent.toLowerCase()))
-    return labels.some(label => label.includes(this.searchTerm))
+  issueTargetConnected(issue) {
+    this.#addIssueToFuse(issue);
   }
 
   get searchTerm() {
-    return normalizeText(this.searchInputTarget.value.toLowerCase());
+    return this.searchInputTarget.value.trim()
   }
+
+  issueTargetConnected(issue) {
+    this.#addIssueToFuse(issue);
+  }
+
+  issueTargetDisconnected(issue) {
+    this.fuse.remove(fuseItem => fuseItem.issue === issue);
+  }
+
+  #addIssueToFuse(issue) {
+    const issueData = {
+      title: issue.querySelector("[data-issue-title]").textContent.toLowerCase(),
+      labels: [...issue.querySelectorAll("[data-issue-label]")].map(label => label.textContent.toLowerCase()),
+      issue
+    }
+
+    this.fuse.add(issueData);
+  }
+
 }

--- a/app/javascript/controllers/visualization/issue_filtering_controller.js
+++ b/app/javascript/controllers/visualization/issue_filtering_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [
+    "searchInput",
+    "issue"
+  ];
+
+  filterIssues() {
+    this.issueTargets.forEach((issue) => {
+      const hasMatch = this.#matchesTitle(issue) || this.#matchesLabels(issue)
+
+      if (hasMatch) {
+        issue.style.display = "block";
+      } else {
+        issue.style.display = "none";
+      }
+    })
+  }
+
+  #matchesTitle(issue) {
+    const title = issue.querySelector("[data-issue-title]").textContent.toLowerCase()
+    return title.includes(this.searchTerm)
+  }
+  #matchesLabels(issue) {
+    const labels = [...issue.querySelectorAll("[data-issue-label]")].map(label => label.textContent.toLowerCase())
+    return labels.some(label => label.includes(this.searchTerm))
+  }
+
+  get searchTerm() {
+    return this.searchInputTarget.value.toLowerCase();
+  }
+}

--- a/app/javascript/controllers/visualization/issue_filtering_controller.js
+++ b/app/javascript/controllers/visualization/issue_filtering_controller.js
@@ -34,14 +34,14 @@ export default class extends Controller {
 
   filterIssues() {
     if (this.searchTerm === "") {
-      this.issueTargets.forEach(issue => (issue.style.display = "block"));
+      this.issueTargets.forEach(issue => (issue.dataset.isIssueSearchMatch = true));
       return;
     }
 
     const issuesMatches = this.fuse.search(this.searchTerm).map(result => result.item.issue)
 
     this.issueTargets.forEach(issue => {
-      issue.style.display = issuesMatches.includes(issue) ? "block" : "none"
+      issue.dataset.isIssueSearchMatch = issuesMatches.includes(issue)
     });
   }
 

--- a/app/models/issue_label.rb
+++ b/app/models/issue_label.rb
@@ -18,4 +18,8 @@ class IssueLabel < ApplicationRecord
   def strip_title_whitepaces
     self.title = self.title&.strip
   end
+
+  def to_s
+    title
+  end
 end

--- a/app/models/issue_label_link.rb
+++ b/app/models/issue_label_link.rb
@@ -1,5 +1,5 @@
 class IssueLabelLink < ApplicationRecord
-  belongs_to :issue
+  belongs_to :issue, touch: true
   belongs_to :issue_label
 
   validates :issue_label_id, uniqueness: { scope: :issue_id }

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -21,7 +21,7 @@
     </h2>
 
 
-    <p class="mt-2 hide-if-empty" data-issue-label>
+    <p class="mt-2 flex gap-2 flex-wrap hide-if-empty" data-issue-label>
       <% issue.labels.each do |label| %>
         <%= badge_for_label(label) %>
       <% end %>

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -21,7 +21,7 @@
     </h2>
 
 
-    <p class="mt-2 flex gap-2 flex-wrap hide-if-empty" data-issue-label>
+    <p class="mt-2 flex gap-2 flex-wrap hide-if-empty">
       <% issue.labels.each do |label| %>
         <%= badge_for_label(label) %>
       <% end %>

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -4,7 +4,7 @@
   data-visualization--board--card-scroll-on-connect-value="<%= local_assigns[:scroll_on_connect] == true %>"
   data-grouping-column-target="card"
   data-grouping-column-issue-id-value="<%= issue.id %>"
-  >
+  data-visualization--issue-filtering-target="issue">
   <%= link_to show_visualization_issue_path(visualization, issue),
     class: "group relative flex flex-col text-sm text-content-500 border-2 border-background-200 bg-background-50 hover:bg-background-100 hover:border-background-900 cursor-pointer shadow-sm rounded-xl card p-3",
     data: {
@@ -16,9 +16,14 @@
       <i class="fa fa-pencil"></i>
     </div>
 
-    <h2 class="font-normal grow break-all">
+    <h2 class="font-normal grow break-all" data-issue-title>
       <%= issue.title %>
     </h2>
+
+
+    <p class="font-normal grow break-all" data-issue-label>
+      <%= issue.labels.join(" | ") %>
+    </p>
 
     <%= render partial: 'visualizations/groupings/_card/icons', locals: { issue: } %>
   <% end %>

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -21,8 +21,10 @@
     </h2>
 
 
-    <p class="font-normal grow break-all" data-issue-label>
-      <%= issue.labels.join(" | ") %>
+    <p class="mt-2 hide-if-empty" data-issue-label>
+      <% issue.labels.each do |label| %>
+        <%= badge_for_label(label) %>
+      <% end %>
     </p>
 
     <%= render partial: 'visualizations/groupings/_card/icons', locals: { issue: } %>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -2,7 +2,11 @@
 
 <%= turbo_stream_from @visualization %>
 
-<main class="grow">
+<main class="grow" data-controller="visualization--issue-filtering">
+  <input type="text"
+    class="input-primary"
+    data-visualization--issue-filtering-target="searchInput"
+    data-action="input->visualization--issue-filtering#filterIssues"/>
   <div class="flex flex-col h-full">
     <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6 p-4 sm:px-12 pt-12">
       <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -42,11 +42,11 @@
           <div class="icon-wrapper">
             <i class="text-readable-content-300 fa fa-search"></i>
           </div>
-          <input class="input-contrast input-sm active"
+          <input class="input-contrast input-sm active cpy-issues-search"
             placeholder="Search issue"
             data-visualization--issue-filtering-target="searchInput"
             data-action="input->visualization--issue-filtering#filterIssues"
-            class="form-input pl-9 bg-body-contrast dark:bg-gray-800" type="search" placeholder="Search…">
+            type="search" placeholder="Search…">
         </div>
       </div>
 

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -4,37 +4,30 @@
 
 <main class="grow" data-controller="visualization--issue-filtering">
   <div class="flex flex-col h-full">
-    <div class="flex flex-col sm:flex-row items-center justify-between gap-2 sm:px-12 pt-4">
-      <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
-        <%= @visualization.project.name %>
-      </h2>
+    <div class="flex flex-col sm:px-12 pt-4">
+      <div class="flex  items-end justify-between gap-2">
+        <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
+          <%= @visualization.project.name %>
+        </h2>
 
-      <div class="flex items-stretch flex-col sm:flex-row gap-4">
-        <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "flex items-center link-secondary flex p-4", data: { turbo_frame: "_top" } do %>
-          <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
-          <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
+        <div class="flex items-stretch flex-col sm:flex-row gap-4">
+          <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "flex items-center link-secondary flex", data: { turbo_frame: "_top" } do %>
+            <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
+            <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
+          <% end %>
+        </div>
+        </div>
+      <div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
+        <%= link_to project_issues_path(@visualization.project), class: "px-2 pb-1 whitespace-nowrap" do %>
+          <%= t(:all_issues, scope: :nav) %>
+        <% end %>
+
+        <%= link_to '#', class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
+          <%= t(:board_view, scope: :nav) %>
         <% end %>
       </div>
     </div>
 
-
-    <div class="px-4 sm:px-12">
-      <div class="relative">
-        <div class="absolute w-full bottom-0 h-px bg-body-contrast" aria-hidden="true"></div>
-        <ul class="relative text-sm font-medium flex flex-nowrap overflow-hidden no-scrollbar">
-          <li class="mr-6">
-            <%= link_to project_issues_path(@visualization.project), class: "block pb-2 whitespace-nowrap" do %>
-              <%= t(:all_issues, scope: :nav) %>
-            <% end %>
-          </li>
-          <li class="mr-6">
-            <%= link_to '#', class: "block pb-2 border-b-2 border-primary whitespace-nowrap" do %>
-              <%= t(:board_view, scope: :nav) %>
-            <% end %>
-          </li>
-        </ul>
-      </div>
-    </div>
 
     <%= turbo_frame_tag('grouping_form') {} %>
 
@@ -43,23 +36,20 @@
     <% else %>
       <%= turbo_frame_tag('issue_form') {} %>
     <% end %>
-    <div class="px-12 flex justify-between items-center">
+    <div class="px-4 sm:px-12 flex justify-between items-center">
       <div class="flex items-stretch gap-4">
-        <form class="relative">
-            <label for="action-search" class="sr-only">Search</label>
-            <input
-            class="input-primary"
+        <div class="input-with-icon-wrapper w-64">
+          <div class="icon-wrapper">
+            <i class="text-readable-content-300 fa fa-search"></i>
+          </div>
+          <input class="input-contrast input-sm active"
+            placeholder="Search issue"
             data-visualization--issue-filtering-target="searchInput"
             data-action="input->visualization--issue-filtering#filterIssues"
             class="form-input pl-9 bg-body-contrast dark:bg-gray-800" type="search" placeholder="Search…">
-            <button class="absolute inset-0 right-auto group" type="submit" aria-label="Search">
-                <svg class="shrink-0 fill-current text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400 ml-3 mr-2" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M7 14c-3.86 0-7-3.14-7-7s3.14-7 7-7 7 3.14 7 7-3.14 7-7 7zM7 2C4.243 2 2 4.243 2 7s2.243 5 5 5 5-2.243 5-5-2.243-5-5-5z"></path>
-                    <path d="M15.707 14.293L13.314 11.9a8.019 8.019 0 01-1.414 1.414l2.393 2.393a.997.997 0 001.414 0 .999.999 0 000-1.414z"></path>
-                </svg>
-            </button>
-        </form>
+        </div>
       </div>
+
       <div class="flex items-stretch flex-col sm:flex-row gap-4 my-4">
         <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
           <i class="fa-solid fa-plus mr-2"></i>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -3,33 +3,22 @@
 <%= turbo_stream_from @visualization %>
 
 <main class="grow" data-controller="visualization--issue-filtering">
-  <input type="text"
-    class="input-primary"
-    data-visualization--issue-filtering-target="searchInput"
-    data-action="input->visualization--issue-filtering#filterIssues"/>
   <div class="flex flex-col h-full">
-    <div class="flex flex-col sm:flex-row items-center justify-between gap-3 mb-6 p-4 sm:px-12 pt-12">
+    <div class="flex flex-col sm:flex-row items-center justify-between gap-2 sm:px-12 pt-4">
       <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
-        <%= @visualization.project.name %> - <%= Visualization.model_name.human(count: 1) %>
+        <%= @visualization.project.name %>
       </h2>
 
       <div class="flex items-stretch flex-col sm:flex-row gap-4">
         <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "flex items-center link-secondary flex p-4", data: { turbo_frame: "_top" } do %>
           <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
-          <span class="sm:block"><%= t("actions.go_to_time_tracking") %></span>
-        <% end %>
-        <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-primary", data: { turbo_frame: 'grouping_form' } do %>
-          <i class="fa-solid fa-plus mr-2"></i>
-
-          <h2 class="grow font-semibold truncate">
-            <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
-          </h2>
-
+          <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
         <% end %>
       </div>
     </div>
 
-    <div class="mb-4 px-4 sm:px-12">
+
+    <div class="px-4 sm:px-12">
       <div class="relative">
         <div class="absolute w-full bottom-0 h-px bg-body-contrast" aria-hidden="true"></div>
         <ul class="relative text-sm font-medium flex flex-nowrap overflow-hidden no-scrollbar">
@@ -39,7 +28,7 @@
             <% end %>
           </li>
           <li class="mr-6">
-            <%= link_to visualization_path(@visualization), class: "block pb-2 border-b-2 border-primary whitespace-nowrap" do %>
+            <%= link_to '#', class: "block pb-2 border-b-2 border-primary whitespace-nowrap" do %>
               <%= t(:board_view, scope: :nav) %>
             <% end %>
           </li>
@@ -54,6 +43,43 @@
     <% else %>
       <%= turbo_frame_tag('issue_form') {} %>
     <% end %>
+    <div class="px-12 flex justify-between items-center">
+      <div class="flex items-stretch gap-4">
+        <form class="relative">
+            <label for="action-search" class="sr-only">Search</label>
+            <input
+            class="input-primary"
+            data-visualization--issue-filtering-target="searchInput"
+            data-action="input->visualization--issue-filtering#filterIssues"
+            class="form-input pl-9 bg-body-contrast dark:bg-gray-800" type="search" placeholder="Search…">
+            <button class="absolute inset-0 right-auto group" type="submit" aria-label="Search">
+                <svg class="shrink-0 fill-current text-gray-400 dark:text-gray-500 group-hover:text-gray-500 dark:group-hover:text-gray-400 ml-3 mr-2" width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M7 14c-3.86 0-7-3.14-7-7s3.14-7 7-7 7 3.14 7 7-3.14 7-7 7zM7 2C4.243 2 2 4.243 2 7s2.243 5 5 5 5-2.243 5-5-2.243-5-5-5z"></path>
+                    <path d="M15.707 14.293L13.314 11.9a8.019 8.019 0 01-1.414 1.414l2.393 2.393a.997.997 0 001.414 0 .999.999 0 000-1.414z"></path>
+                </svg>
+            </button>
+        </form>
+      </div>
+      <div class="flex items-stretch flex-col sm:flex-row gap-4 my-4">
+        <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
+          <i class="fa-solid fa-plus mr-2"></i>
+
+          <h2 class="grow font-semibold truncate">
+            <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
+          </h2>
+
+        <% end %>
+      </div>
+    </div>
+
+    <%= turbo_frame_tag('grouping_form') {} %>
+
+    <% if @open_issue.present? %>
+      <%= render partial: 'visualizations/issues/form', locals: { issue: @open_issue, visualization: @visualization } %>
+    <% else %>
+      <%= turbo_frame_tag('issue_form') {} %>
+    <% end %>
+
 
     <div class="relative grow cpy-columns-wrapper">
       <div class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:pl-12 sm:pr-12 sm:pb-4 sm:scroll-pr-12 pb-2 sm:px-12 gap-x-8 flex flex-row overflow-x-auto overflow-y-hidden scroll-smooth">
@@ -70,7 +96,6 @@
             visualization: @visualization,
             open_issue:  @open_issue
           } %>
-
         </ul>
 
         <div class="w-64 shrink-0">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -18,6 +18,7 @@ pin "jquery" # @3.7.1
 pin "sortablejs" # @1.15.6
 pin "dropzone" # @6.0.0
 pin "just-extend" # @5.1.1 required by dropzone
+pin "fuse.js" # @7.1.0
 
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/javascript/controllers/visualizations", under: "controllers"

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -10,8 +10,8 @@ en:
         other: 'Projects'
 
       visualization:
-        one: 'Board view'
-        other: 'Board views'
+        one: 'Workflow Board'
+        other: 'Workflow Board'
 
       grouping:
         one: 'Column'

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -10,8 +10,8 @@ pt-BR:
         other: 'Projetos'
 
       visualization:
-        one: 'Visão de quadro'
-        other: 'Visões de quadros'
+        one: 'Quadro de Trabalho'
+        other: 'Quadro de Trabalho'
 
       grouping:
         one: 'Coluna'

--- a/config/locales/page_title.en.yml
+++ b/config/locales/page_title.en.yml
@@ -2,7 +2,7 @@ en:
   page_title:
     time_tracking: "Time Tracking"
     projects: "Projects"
-    project_board: "%{project_name} - Board"
+    project_board: "%{project_name} - Workflow Board"
     reports: "Reports"
     edit_profile: "Profile and Newsletter"
     project_all_issues: "%{project_name} - All issues"

--- a/config/locales/page_title.pt-BR.yml
+++ b/config/locales/page_title.pt-BR.yml
@@ -2,7 +2,7 @@ pt-BR:
   page_title:
     time_tracking: "Registro de Tempo"
     projects: "Projetos"
-    project_board: "%{project_name} - Quadro"
+    project_board: "%{project_name} - Quadro de Trabalho"
     reports: "Relatórios"
     edit_profile: "Perfil e Newsletter"
     project_all_issues: "%{project_name} - Todas as issues"

--- a/spec/features/project_management/kanban/filtering_issues_spec.rb
+++ b/spec/features/project_management/kanban/filtering_issues_spec.rb
@@ -16,7 +16,7 @@ describe 'As a project manager, I want to filter my issues from Workflow Boards'
   let!(:issue_deploy) { FactoryBot.create(:issue, title: "Deploy", project: project) }
 
   let!(:label_development) { project.issue_labels.create!(title: 'DeveloPment') }
-  let!(:label_urgent) { project.issue_labels.create!(title: 'UrRgent') }
+  let!(:label_urgent) { project.issue_labels.create!(title: 'URgent') }
 
   before(:each) do
     issue_setup.labels << label_urgent

--- a/spec/features/project_management/kanban/filtering_issues_spec.rb
+++ b/spec/features/project_management/kanban/filtering_issues_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+# TODO: split 'managing_kanban_spec' into more files and move some specs to here
+describe 'As a project manager, I want to filter my issues from Workflow Boards' do
+  let!(:user) { FactoryBot.create(:user) }
+
+  let!(:project) { FactoryBot.create(:project) }
+  let!(:grouping_todo) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO") }
+  let!(:grouping_doing) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "DOING") }
+  let!(:grouping_done) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "DONE") }
+  let!(:issue_setup) { FactoryBot.create(:issue, title: "Setup", project: project) }
+
+  let!(:issue_development1) { FactoryBot.create(:issue, title: "Bigtask 1", project: project) }
+  let!(:issue_development2) { FactoryBot.create(:issue, title: "Bigtask 2", project: project) }
+  let!(:issue_development3) { FactoryBot.create(:issue, title: "Bigtask 3", project: project) }
+  let!(:issue_deploy) { FactoryBot.create(:issue, title: "Deploy", project: project) }
+
+  let!(:label_development) { project.issue_labels.create!(title: 'DeveloPment') }
+  let!(:label_urgent) { project.issue_labels.create!(title: 'UrRgent') }
+
+  before(:each) do
+    issue_setup.labels << label_urgent
+
+    issue_development1.labels << label_development
+    issue_development2.labels << label_development
+    issue_development3.labels << label_development
+
+    issue_deploy.labels << label_urgent
+
+    grouping_todo.issues << issue_deploy
+    grouping_todo.issues << issue_development1
+    grouping_todo.issues << issue_development2
+
+    grouping_doing.issues << issue_development3
+
+    grouping_done.issues << issue_deploy
+  end
+
+  specify "I can filter by issue title" do
+    visit visualization_path(project.default_visualization)
+
+    find(".cpy-issues-search").send_keys 'Bigtask'
+
+    within '.cpy-columns-wrapper' do
+      expect(page).to_not have_content("Setup")
+      expect(page).to_not have_content("Deploy")
+
+      expect(page).to have_content("Bigtask 1")
+      expect(page).to have_content("Bigtask 2")
+      expect(page).to have_content("Bigtask 3")
+    end
+  end
+
+
+  specify "I can filter by issue labels" do
+    visit visualization_path(project.default_visualization)
+
+    find(".cpy-issues-search").send_keys 'urgent'
+
+    within '.cpy-columns-wrapper' do
+      expect(page).to_not have_content("Setup")
+      expect(page).to_not have_content("Bigtask 1")
+      expect(page).to_not have_content("Bigtask 2")
+      expect(page).to_not have_content("Bigtask 3")
+
+      expect(page).to have_content("Deploy")
+    end
+  end
+end

--- a/spec/features/project_management/kanban/managing_issues_data_spec.rb
+++ b/spec/features/project_management/kanban/managing_issues_data_spec.rb
@@ -1,79 +1,77 @@
 require 'rails_helper'
 
 # TODO: split 'managing_kanban_spec' into more files and move some specs to here
-describe 'As a project manager, I want to manage my issues from KanbanBoard' do
+describe 'As a project manager, I want to manage my issues from Workflow Boards' do
   let!(:user) { FactoryBot.create(:user) }
 
-  context "Managing Tags" do
-    let!(:project) { FactoryBot.create(:project) }
-    let!(:grouping) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO") }
-    let!(:issue) { FactoryBot.create(:issue, title: "Issue testing title", description: "Issue description", project: project) }
+  let!(:project) { FactoryBot.create(:project) }
+  let!(:grouping) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO") }
+  let!(:issue) { FactoryBot.create(:issue, title: "Issue testing title", description: "Issue description", project: project) }
 
-    let!(:label_development) { project.issue_labels.create!(title: 'Development') }
-    let!(:label_marketing) { project.issue_labels.create!(title: 'Marketing') }
-    let!(:label_urgent) { project.issue_labels.create!(title: 'Urgent') }
+  let!(:label_development) { project.issue_labels.create!(title: 'Development') }
+  let!(:label_marketing) { project.issue_labels.create!(title: 'Marketing') }
+  let!(:label_urgent) { project.issue_labels.create!(title: 'Urgent') }
 
-    before(:each) do
-      FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+  before(:each) do
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+  end
+
+  specify "I can see applied tags" do
+    issue.labels << label_marketing
+
+    visit show_visualization_issue_path(project.default_visualization, issue)
+
+
+    within ".cpy-issue-labels .select2-selection__rendered" do
+      expect(page).to have_content("Marketing")
+    end
+  end
+
+  specify "I can add an existing tag" do
+    issue.labels << label_marketing
+
+    visit show_visualization_issue_path(project.default_visualization, issue)
+
+    select_from_select2 selector: '.cpy-issue-labels .select2', option_text: 'Development'
+
+    within ".cpy-issue-labels .select2-selection__rendered" do
+      expect(page).to have_content("Marketing")
+      expect(page).to have_content("Development")
     end
 
-    specify "I can see applied tags" do
-      issue.labels << label_marketing
+    issue.reload
+    expect(issue.labels).to eq([ label_development, label_marketing ])
+  end
 
-      visit show_visualization_issue_path(project.default_visualization, issue)
+  specify "I can add a new tag" do
+    issue.labels << label_marketing
 
+    visit show_visualization_issue_path(project.default_visualization, issue)
 
-      within ".cpy-issue-labels .select2-selection__rendered" do
-        expect(page).to have_content("Marketing")
-      end
+    add_to_select2 selector: '.cpy-issue-labels .select2', option_text: 'nice-to-have'
+
+    within ".cpy-issue-labels .select2-selection__rendered" do
+      expect(page).to have_content("Marketing")
+      expect(page).to have_content("nice-to-have")
     end
 
-    specify "I can add an existing tag" do
-      issue.labels << label_marketing
+    issue.reload
+    expect(issue.labels.last.title).to eq('nice-to-have')
+  end
 
-      visit show_visualization_issue_path(project.default_visualization, issue)
+  specify "I can remove a tag" do
+    issue.labels << label_marketing
+    issue.labels << label_development
 
-      select_from_select2 selector: '.cpy-issue-labels .select2', option_text: 'Development'
+    visit show_visualization_issue_path(project.default_visualization, issue)
 
-      within ".cpy-issue-labels .select2-selection__rendered" do
-        expect(page).to have_content("Marketing")
-        expect(page).to have_content("Development")
-      end
-
-      issue.reload
-      expect(issue.labels).to eq([ label_development, label_marketing ])
+    within ".cpy-issue-labels .select2-selection__rendered" do
+      find(".select2-selection__choice[title='Development'] .select2-selection__choice__remove").click
+      expect(page).to have_content("Marketing")
+      expect(page).to_not have_content("Development")
     end
 
-    specify "I can add a new tag" do
-      issue.labels << label_marketing
-
-      visit show_visualization_issue_path(project.default_visualization, issue)
-
-      add_to_select2 selector: '.cpy-issue-labels .select2', option_text: 'nice-to-have'
-
-      within ".cpy-issue-labels .select2-selection__rendered" do
-        expect(page).to have_content("Marketing")
-        expect(page).to have_content("nice-to-have")
-      end
-
-      issue.reload
-      expect(issue.labels.last.title).to eq('nice-to-have')
-    end
-
-    specify "I can remove a tag" do
-      issue.labels << label_marketing
-      issue.labels << label_development
-
-      visit show_visualization_issue_path(project.default_visualization, issue)
-
-      within ".cpy-issue-labels .select2-selection__rendered" do
-        find(".select2-selection__choice[title='Development'] .select2-selection__choice__remove").click
-        expect(page).to have_content("Marketing")
-        expect(page).to_not have_content("Development")
-      end
-
-      issue.reload
-      expect(issue.labels).to eq([ label_marketing ])
-    end
+    issue.reload
+    expect(issue.labels).to eq([ label_marketing ])
   end
 end

--- a/vendor/javascript/fuse.js.js
+++ b/vendor/javascript/fuse.js.js
@@ -1,0 +1,1796 @@
+// fuse.js downloaded from https://cdn.jsdelivr.net/npm/fuse.js/dist/fuse.mjs
+
+/**
+ * Fuse.js v7.1.0 - Lightweight fuzzy-search (http://fusejs.io)
+ *
+ * Copyright (c) 2025 Kiro Risk (http://kiro.me)
+ * All Rights Reserved. Apache Software License 2.0
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+function isArray(value) {
+  return !Array.isArray
+    ? getTag(value) === '[object Array]'
+    : Array.isArray(value)
+}
+
+// Adapted from: https://github.com/lodash/lodash/blob/master/.internal/baseToString.js
+const INFINITY = 1 / 0;
+function baseToString(value) {
+  // Exit early for strings to avoid a performance hit in some environments.
+  if (typeof value == 'string') {
+    return value
+  }
+  let result = value + '';
+  return result == '0' && 1 / value == -INFINITY ? '-0' : result
+}
+
+function toString(value) {
+  return value == null ? '' : baseToString(value)
+}
+
+function isString(value) {
+  return typeof value === 'string'
+}
+
+function isNumber(value) {
+  return typeof value === 'number'
+}
+
+// Adapted from: https://github.com/lodash/lodash/blob/master/isBoolean.js
+function isBoolean(value) {
+  return (
+    value === true ||
+    value === false ||
+    (isObjectLike(value) && getTag(value) == '[object Boolean]')
+  )
+}
+
+function isObject(value) {
+  return typeof value === 'object'
+}
+
+// Checks if `value` is object-like.
+function isObjectLike(value) {
+  return isObject(value) && value !== null
+}
+
+function isDefined(value) {
+  return value !== undefined && value !== null
+}
+
+function isBlank(value) {
+  return !value.trim().length
+}
+
+// Gets the `toStringTag` of `value`.
+// Adapted from: https://github.com/lodash/lodash/blob/master/.internal/getTag.js
+function getTag(value) {
+  return value == null
+    ? value === undefined
+      ? '[object Undefined]'
+      : '[object Null]'
+    : Object.prototype.toString.call(value)
+}
+
+const EXTENDED_SEARCH_UNAVAILABLE = 'Extended search is not available';
+
+const INCORRECT_INDEX_TYPE = "Incorrect 'index' type";
+
+const LOGICAL_SEARCH_INVALID_QUERY_FOR_KEY = (key) =>
+  `Invalid value for key ${key}`;
+
+const PATTERN_LENGTH_TOO_LARGE = (max) =>
+  `Pattern length exceeds max of ${max}.`;
+
+const MISSING_KEY_PROPERTY = (name) => `Missing ${name} property in key`;
+
+const INVALID_KEY_WEIGHT_VALUE = (key) =>
+  `Property 'weight' in key '${key}' must be a positive integer`;
+
+const hasOwn = Object.prototype.hasOwnProperty;
+
+class KeyStore {
+  constructor(keys) {
+    this._keys = [];
+    this._keyMap = {};
+
+    let totalWeight = 0;
+
+    keys.forEach((key) => {
+      let obj = createKey(key);
+
+      this._keys.push(obj);
+      this._keyMap[obj.id] = obj;
+
+      totalWeight += obj.weight;
+    });
+
+    // Normalize weights so that their sum is equal to 1
+    this._keys.forEach((key) => {
+      key.weight /= totalWeight;
+    });
+  }
+  get(keyId) {
+    return this._keyMap[keyId]
+  }
+  keys() {
+    return this._keys
+  }
+  toJSON() {
+    return JSON.stringify(this._keys)
+  }
+}
+
+function createKey(key) {
+  let path = null;
+  let id = null;
+  let src = null;
+  let weight = 1;
+  let getFn = null;
+
+  if (isString(key) || isArray(key)) {
+    src = key;
+    path = createKeyPath(key);
+    id = createKeyId(key);
+  } else {
+    if (!hasOwn.call(key, 'name')) {
+      throw new Error(MISSING_KEY_PROPERTY('name'))
+    }
+
+    const name = key.name;
+    src = name;
+
+    if (hasOwn.call(key, 'weight')) {
+      weight = key.weight;
+
+      if (weight <= 0) {
+        throw new Error(INVALID_KEY_WEIGHT_VALUE(name))
+      }
+    }
+
+    path = createKeyPath(name);
+    id = createKeyId(name);
+    getFn = key.getFn;
+  }
+
+  return { path, id, weight, src, getFn }
+}
+
+function createKeyPath(key) {
+  return isArray(key) ? key : key.split('.')
+}
+
+function createKeyId(key) {
+  return isArray(key) ? key.join('.') : key
+}
+
+function get(obj, path) {
+  let list = [];
+  let arr = false;
+
+  const deepGet = (obj, path, index) => {
+    if (!isDefined(obj)) {
+      return
+    }
+    if (!path[index]) {
+      // If there's no path left, we've arrived at the object we care about.
+      list.push(obj);
+    } else {
+      let key = path[index];
+
+      const value = obj[key];
+
+      if (!isDefined(value)) {
+        return
+      }
+
+      // If we're at the last value in the path, and if it's a string/number/bool,
+      // add it to the list
+      if (
+        index === path.length - 1 &&
+        (isString(value) || isNumber(value) || isBoolean(value))
+      ) {
+        list.push(toString(value));
+      } else if (isArray(value)) {
+        arr = true;
+        // Search each item in the array.
+        for (let i = 0, len = value.length; i < len; i += 1) {
+          deepGet(value[i], path, index + 1);
+        }
+      } else if (path.length) {
+        // An object. Recurse further.
+        deepGet(value, path, index + 1);
+      }
+    }
+  };
+
+  // Backwards compatibility (since path used to be a string)
+  deepGet(obj, isString(path) ? path.split('.') : path, 0);
+
+  return arr ? list : list[0]
+}
+
+const MatchOptions = {
+  // Whether the matches should be included in the result set. When `true`, each record in the result
+  // set will include the indices of the matched characters.
+  // These can consequently be used for highlighting purposes.
+  includeMatches: false,
+  // When `true`, the matching function will continue to the end of a search pattern even if
+  // a perfect match has already been located in the string.
+  findAllMatches: false,
+  // Minimum number of characters that must be matched before a result is considered a match
+  minMatchCharLength: 1
+};
+
+const BasicOptions = {
+  // When `true`, the algorithm continues searching to the end of the input even if a perfect
+  // match is found before the end of the same input.
+  isCaseSensitive: false,
+  // When `true`, the algorithm will ignore diacritics (accents) in comparisons
+  ignoreDiacritics: false,
+  // When true, the matching function will continue to the end of a search pattern even if
+  includeScore: false,
+  // List of properties that will be searched. This also supports nested properties.
+  keys: [],
+  // Whether to sort the result list, by score
+  shouldSort: true,
+  // Default sort function: sort by ascending score, ascending index
+  sortFn: (a, b) =>
+    a.score === b.score ? (a.idx < b.idx ? -1 : 1) : a.score < b.score ? -1 : 1
+};
+
+const FuzzyOptions = {
+  // Approximately where in the text is the pattern expected to be found?
+  location: 0,
+  // At what point does the match algorithm give up. A threshold of '0.0' requires a perfect match
+  // (of both letters and location), a threshold of '1.0' would match anything.
+  threshold: 0.6,
+  // Determines how close the match must be to the fuzzy location (specified above).
+  // An exact letter match which is 'distance' characters away from the fuzzy location
+  // would score as a complete mismatch. A distance of '0' requires the match be at
+  // the exact location specified, a threshold of '1000' would require a perfect match
+  // to be within 800 characters of the fuzzy location to be found using a 0.8 threshold.
+  distance: 100
+};
+
+const AdvancedOptions = {
+  // When `true`, it enables the use of unix-like search commands
+  useExtendedSearch: false,
+  // The get function to use when fetching an object's properties.
+  // The default will search nested paths *ie foo.bar.baz*
+  getFn: get,
+  // When `true`, search will ignore `location` and `distance`, so it won't matter
+  // where in the string the pattern appears.
+  // More info: https://fusejs.io/concepts/scoring-theory.html#fuzziness-score
+  ignoreLocation: false,
+  // When `true`, the calculation for the relevance score (used for sorting) will
+  // ignore the field-length norm.
+  // More info: https://fusejs.io/concepts/scoring-theory.html#field-length-norm
+  ignoreFieldNorm: false,
+  // The weight to determine how much field length norm effects scoring.
+  fieldNormWeight: 1
+};
+
+var Config = {
+  ...BasicOptions,
+  ...MatchOptions,
+  ...FuzzyOptions,
+  ...AdvancedOptions
+};
+
+const SPACE = /[^ ]+/g;
+
+// Field-length norm: the shorter the field, the higher the weight.
+// Set to 3 decimals to reduce index size.
+function norm(weight = 1, mantissa = 3) {
+  const cache = new Map();
+  const m = Math.pow(10, mantissa);
+
+  return {
+    get(value) {
+      const numTokens = value.match(SPACE).length;
+
+      if (cache.has(numTokens)) {
+        return cache.get(numTokens)
+      }
+
+      // Default function is 1/sqrt(x), weight makes that variable
+      const norm = 1 / Math.pow(numTokens, 0.5 * weight);
+
+      // In place of `toFixed(mantissa)`, for faster computation
+      const n = parseFloat(Math.round(norm * m) / m);
+
+      cache.set(numTokens, n);
+
+      return n
+    },
+    clear() {
+      cache.clear();
+    }
+  }
+}
+
+class FuseIndex {
+  constructor({
+    getFn = Config.getFn,
+    fieldNormWeight = Config.fieldNormWeight
+  } = {}) {
+    this.norm = norm(fieldNormWeight, 3);
+    this.getFn = getFn;
+    this.isCreated = false;
+
+    this.setIndexRecords();
+  }
+  setSources(docs = []) {
+    this.docs = docs;
+  }
+  setIndexRecords(records = []) {
+    this.records = records;
+  }
+  setKeys(keys = []) {
+    this.keys = keys;
+    this._keysMap = {};
+    keys.forEach((key, idx) => {
+      this._keysMap[key.id] = idx;
+    });
+  }
+  create() {
+    if (this.isCreated || !this.docs.length) {
+      return
+    }
+
+    this.isCreated = true;
+
+    // List is Array<String>
+    if (isString(this.docs[0])) {
+      this.docs.forEach((doc, docIndex) => {
+        this._addString(doc, docIndex);
+      });
+    } else {
+      // List is Array<Object>
+      this.docs.forEach((doc, docIndex) => {
+        this._addObject(doc, docIndex);
+      });
+    }
+
+    this.norm.clear();
+  }
+  // Adds a doc to the end of the index
+  add(doc) {
+    const idx = this.size();
+
+    if (isString(doc)) {
+      this._addString(doc, idx);
+    } else {
+      this._addObject(doc, idx);
+    }
+  }
+  // Removes the doc at the specified index of the index
+  removeAt(idx) {
+    this.records.splice(idx, 1);
+
+    // Change ref index of every subsquent doc
+    for (let i = idx, len = this.size(); i < len; i += 1) {
+      this.records[i].i -= 1;
+    }
+  }
+  getValueForItemAtKeyId(item, keyId) {
+    return item[this._keysMap[keyId]]
+  }
+  size() {
+    return this.records.length
+  }
+  _addString(doc, docIndex) {
+    if (!isDefined(doc) || isBlank(doc)) {
+      return
+    }
+
+    let record = {
+      v: doc,
+      i: docIndex,
+      n: this.norm.get(doc)
+    };
+
+    this.records.push(record);
+  }
+  _addObject(doc, docIndex) {
+    let record = { i: docIndex, $: {} };
+
+    // Iterate over every key (i.e, path), and fetch the value at that key
+    this.keys.forEach((key, keyIndex) => {
+      let value = key.getFn ? key.getFn(doc) : this.getFn(doc, key.path);
+
+      if (!isDefined(value)) {
+        return
+      }
+
+      if (isArray(value)) {
+        let subRecords = [];
+        const stack = [{ nestedArrIndex: -1, value }];
+
+        while (stack.length) {
+          const { nestedArrIndex, value } = stack.pop();
+
+          if (!isDefined(value)) {
+            continue
+          }
+
+          if (isString(value) && !isBlank(value)) {
+            let subRecord = {
+              v: value,
+              i: nestedArrIndex,
+              n: this.norm.get(value)
+            };
+
+            subRecords.push(subRecord);
+          } else if (isArray(value)) {
+            value.forEach((item, k) => {
+              stack.push({
+                nestedArrIndex: k,
+                value: item
+              });
+            });
+          } else ;
+        }
+        record.$[keyIndex] = subRecords;
+      } else if (isString(value) && !isBlank(value)) {
+        let subRecord = {
+          v: value,
+          n: this.norm.get(value)
+        };
+
+        record.$[keyIndex] = subRecord;
+      }
+    });
+
+    this.records.push(record);
+  }
+  toJSON() {
+    return {
+      keys: this.keys,
+      records: this.records
+    }
+  }
+}
+
+function createIndex(
+  keys,
+  docs,
+  { getFn = Config.getFn, fieldNormWeight = Config.fieldNormWeight } = {}
+) {
+  const myIndex = new FuseIndex({ getFn, fieldNormWeight });
+  myIndex.setKeys(keys.map(createKey));
+  myIndex.setSources(docs);
+  myIndex.create();
+  return myIndex
+}
+
+function parseIndex(
+  data,
+  { getFn = Config.getFn, fieldNormWeight = Config.fieldNormWeight } = {}
+) {
+  const { keys, records } = data;
+  const myIndex = new FuseIndex({ getFn, fieldNormWeight });
+  myIndex.setKeys(keys);
+  myIndex.setIndexRecords(records);
+  return myIndex
+}
+
+function computeScore$1(
+  pattern,
+  {
+    errors = 0,
+    currentLocation = 0,
+    expectedLocation = 0,
+    distance = Config.distance,
+    ignoreLocation = Config.ignoreLocation
+  } = {}
+) {
+  const accuracy = errors / pattern.length;
+
+  if (ignoreLocation) {
+    return accuracy
+  }
+
+  const proximity = Math.abs(expectedLocation - currentLocation);
+
+  if (!distance) {
+    // Dodge divide by zero error.
+    return proximity ? 1.0 : accuracy
+  }
+
+  return accuracy + proximity / distance
+}
+
+function convertMaskToIndices(
+  matchmask = [],
+  minMatchCharLength = Config.minMatchCharLength
+) {
+  let indices = [];
+  let start = -1;
+  let end = -1;
+  let i = 0;
+
+  for (let len = matchmask.length; i < len; i += 1) {
+    let match = matchmask[i];
+    if (match && start === -1) {
+      start = i;
+    } else if (!match && start !== -1) {
+      end = i - 1;
+      if (end - start + 1 >= minMatchCharLength) {
+        indices.push([start, end]);
+      }
+      start = -1;
+    }
+  }
+
+  // (i-1 - start) + 1 => i - start
+  if (matchmask[i - 1] && i - start >= minMatchCharLength) {
+    indices.push([start, i - 1]);
+  }
+
+  return indices
+}
+
+// Machine word size
+const MAX_BITS = 32;
+
+function search(
+  text,
+  pattern,
+  patternAlphabet,
+  {
+    location = Config.location,
+    distance = Config.distance,
+    threshold = Config.threshold,
+    findAllMatches = Config.findAllMatches,
+    minMatchCharLength = Config.minMatchCharLength,
+    includeMatches = Config.includeMatches,
+    ignoreLocation = Config.ignoreLocation
+  } = {}
+) {
+  if (pattern.length > MAX_BITS) {
+    throw new Error(PATTERN_LENGTH_TOO_LARGE(MAX_BITS))
+  }
+
+  const patternLen = pattern.length;
+  // Set starting location at beginning text and initialize the alphabet.
+  const textLen = text.length;
+  // Handle the case when location > text.length
+  const expectedLocation = Math.max(0, Math.min(location, textLen));
+  // Highest score beyond which we give up.
+  let currentThreshold = threshold;
+  // Is there a nearby exact match? (speedup)
+  let bestLocation = expectedLocation;
+
+  // Performance: only computer matches when the minMatchCharLength > 1
+  // OR if `includeMatches` is true.
+  const computeMatches = minMatchCharLength > 1 || includeMatches;
+  // A mask of the matches, used for building the indices
+  const matchMask = computeMatches ? Array(textLen) : [];
+
+  let index;
+
+  // Get all exact matches, here for speed up
+  while ((index = text.indexOf(pattern, bestLocation)) > -1) {
+    let score = computeScore$1(pattern, {
+      currentLocation: index,
+      expectedLocation,
+      distance,
+      ignoreLocation
+    });
+
+    currentThreshold = Math.min(score, currentThreshold);
+    bestLocation = index + patternLen;
+
+    if (computeMatches) {
+      let i = 0;
+      while (i < patternLen) {
+        matchMask[index + i] = 1;
+        i += 1;
+      }
+    }
+  }
+
+  // Reset the best location
+  bestLocation = -1;
+
+  let lastBitArr = [];
+  let finalScore = 1;
+  let binMax = patternLen + textLen;
+
+  const mask = 1 << (patternLen - 1);
+
+  for (let i = 0; i < patternLen; i += 1) {
+    // Scan for the best match; each iteration allows for one more error.
+    // Run a binary search to determine how far from the match location we can stray
+    // at this error level.
+    let binMin = 0;
+    let binMid = binMax;
+
+    while (binMin < binMid) {
+      const score = computeScore$1(pattern, {
+        errors: i,
+        currentLocation: expectedLocation + binMid,
+        expectedLocation,
+        distance,
+        ignoreLocation
+      });
+
+      if (score <= currentThreshold) {
+        binMin = binMid;
+      } else {
+        binMax = binMid;
+      }
+
+      binMid = Math.floor((binMax - binMin) / 2 + binMin);
+    }
+
+    // Use the result from this iteration as the maximum for the next.
+    binMax = binMid;
+
+    let start = Math.max(1, expectedLocation - binMid + 1);
+    let finish = findAllMatches
+      ? textLen
+      : Math.min(expectedLocation + binMid, textLen) + patternLen;
+
+    // Initialize the bit array
+    let bitArr = Array(finish + 2);
+
+    bitArr[finish + 1] = (1 << i) - 1;
+
+    for (let j = finish; j >= start; j -= 1) {
+      let currentLocation = j - 1;
+      let charMatch = patternAlphabet[text.charAt(currentLocation)];
+
+      if (computeMatches) {
+        // Speed up: quick bool to int conversion (i.e, `charMatch ? 1 : 0`)
+        matchMask[currentLocation] = +!!charMatch;
+      }
+
+      // First pass: exact match
+      bitArr[j] = ((bitArr[j + 1] << 1) | 1) & charMatch;
+
+      // Subsequent passes: fuzzy match
+      if (i) {
+        bitArr[j] |=
+          ((lastBitArr[j + 1] | lastBitArr[j]) << 1) | 1 | lastBitArr[j + 1];
+      }
+
+      if (bitArr[j] & mask) {
+        finalScore = computeScore$1(pattern, {
+          errors: i,
+          currentLocation,
+          expectedLocation,
+          distance,
+          ignoreLocation
+        });
+
+        // This match will almost certainly be better than any existing match.
+        // But check anyway.
+        if (finalScore <= currentThreshold) {
+          // Indeed it is
+          currentThreshold = finalScore;
+          bestLocation = currentLocation;
+
+          // Already passed `loc`, downhill from here on in.
+          if (bestLocation <= expectedLocation) {
+            break
+          }
+
+          // When passing `bestLocation`, don't exceed our current distance from `expectedLocation`.
+          start = Math.max(1, 2 * expectedLocation - bestLocation);
+        }
+      }
+    }
+
+    // No hope for a (better) match at greater error levels.
+    const score = computeScore$1(pattern, {
+      errors: i + 1,
+      currentLocation: expectedLocation,
+      expectedLocation,
+      distance,
+      ignoreLocation
+    });
+
+    if (score > currentThreshold) {
+      break
+    }
+
+    lastBitArr = bitArr;
+  }
+
+  const result = {
+    isMatch: bestLocation >= 0,
+    // Count exact matches (those with a score of 0) to be "almost" exact
+    score: Math.max(0.001, finalScore)
+  };
+
+  if (computeMatches) {
+    const indices = convertMaskToIndices(matchMask, minMatchCharLength);
+    if (!indices.length) {
+      result.isMatch = false;
+    } else if (includeMatches) {
+      result.indices = indices;
+    }
+  }
+
+  return result
+}
+
+function createPatternAlphabet(pattern) {
+  let mask = {};
+
+  for (let i = 0, len = pattern.length; i < len; i += 1) {
+    const char = pattern.charAt(i);
+    mask[char] = (mask[char] || 0) | (1 << (len - i - 1));
+  }
+
+  return mask
+}
+
+const stripDiacritics = String.prototype.normalize
+    ? ((str) => str.normalize('NFD').replace(/[\u0300-\u036F\u0483-\u0489\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u0711\u0730-\u074A\u07A6-\u07B0\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A70\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B56\u0B57\u0B62\u0B63\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0C00-\u0C04\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D82\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0EB1\u0EB4-\u0EB9\u0EBB\u0EBC\u0EC8-\u0ECD\u0F18\u0F19\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F\u109A-\u109D\u135D-\u135F\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u180B-\u180D\u1885\u1886\u18A9\u1920-\u192B\u1930-\u193B\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F\u1AB0-\u1ABE\u1B00-\u1B04\u1B34-\u1B44\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BE6-\u1BF3\u1C24-\u1C37\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF2-\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u20D0-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA66F-\uA672\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA880\uA881\uA8B4-\uA8C5\uA8E0-\uA8F1\uA8FF\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9E5\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F]/g, ''))
+    : ((str) => str);
+
+class BitapSearch {
+  constructor(
+    pattern,
+    {
+      location = Config.location,
+      threshold = Config.threshold,
+      distance = Config.distance,
+      includeMatches = Config.includeMatches,
+      findAllMatches = Config.findAllMatches,
+      minMatchCharLength = Config.minMatchCharLength,
+      isCaseSensitive = Config.isCaseSensitive,
+      ignoreDiacritics = Config.ignoreDiacritics,
+      ignoreLocation = Config.ignoreLocation
+    } = {}
+  ) {
+    this.options = {
+      location,
+      threshold,
+      distance,
+      includeMatches,
+      findAllMatches,
+      minMatchCharLength,
+      isCaseSensitive,
+      ignoreDiacritics,
+      ignoreLocation
+    };
+
+    pattern = isCaseSensitive ? pattern : pattern.toLowerCase();
+    pattern = ignoreDiacritics ? stripDiacritics(pattern) : pattern;
+    this.pattern = pattern;
+
+    this.chunks = [];
+
+    if (!this.pattern.length) {
+      return
+    }
+
+    const addChunk = (pattern, startIndex) => {
+      this.chunks.push({
+        pattern,
+        alphabet: createPatternAlphabet(pattern),
+        startIndex
+      });
+    };
+
+    const len = this.pattern.length;
+
+    if (len > MAX_BITS) {
+      let i = 0;
+      const remainder = len % MAX_BITS;
+      const end = len - remainder;
+
+      while (i < end) {
+        addChunk(this.pattern.substr(i, MAX_BITS), i);
+        i += MAX_BITS;
+      }
+
+      if (remainder) {
+        const startIndex = len - MAX_BITS;
+        addChunk(this.pattern.substr(startIndex), startIndex);
+      }
+    } else {
+      addChunk(this.pattern, 0);
+    }
+  }
+
+  searchIn(text) {
+    const { isCaseSensitive, ignoreDiacritics, includeMatches } = this.options;
+
+    text = isCaseSensitive ? text : text.toLowerCase();
+    text = ignoreDiacritics ? stripDiacritics(text) : text;
+
+    // Exact match
+    if (this.pattern === text) {
+      let result = {
+        isMatch: true,
+        score: 0
+      };
+
+      if (includeMatches) {
+        result.indices = [[0, text.length - 1]];
+      }
+
+      return result
+    }
+
+    // Otherwise, use Bitap algorithm
+    const {
+      location,
+      distance,
+      threshold,
+      findAllMatches,
+      minMatchCharLength,
+      ignoreLocation
+    } = this.options;
+
+    let allIndices = [];
+    let totalScore = 0;
+    let hasMatches = false;
+
+    this.chunks.forEach(({ pattern, alphabet, startIndex }) => {
+      const { isMatch, score, indices } = search(text, pattern, alphabet, {
+        location: location + startIndex,
+        distance,
+        threshold,
+        findAllMatches,
+        minMatchCharLength,
+        includeMatches,
+        ignoreLocation
+      });
+
+      if (isMatch) {
+        hasMatches = true;
+      }
+
+      totalScore += score;
+
+      if (isMatch && indices) {
+        allIndices = [...allIndices, ...indices];
+      }
+    });
+
+    let result = {
+      isMatch: hasMatches,
+      score: hasMatches ? totalScore / this.chunks.length : 1
+    };
+
+    if (hasMatches && includeMatches) {
+      result.indices = allIndices;
+    }
+
+    return result
+  }
+}
+
+class BaseMatch {
+  constructor(pattern) {
+    this.pattern = pattern;
+  }
+  static isMultiMatch(pattern) {
+    return getMatch(pattern, this.multiRegex)
+  }
+  static isSingleMatch(pattern) {
+    return getMatch(pattern, this.singleRegex)
+  }
+  search(/*text*/) {}
+}
+
+function getMatch(pattern, exp) {
+  const matches = pattern.match(exp);
+  return matches ? matches[1] : null
+}
+
+// Token: 'file
+
+class ExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'exact'
+  }
+  static get multiRegex() {
+    return /^="(.*)"$/
+  }
+  static get singleRegex() {
+    return /^=(.*)$/
+  }
+  search(text) {
+    const isMatch = text === this.pattern;
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [0, this.pattern.length - 1]
+    }
+  }
+}
+
+// Token: !fire
+
+class InverseExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'inverse-exact'
+  }
+  static get multiRegex() {
+    return /^!"(.*)"$/
+  }
+  static get singleRegex() {
+    return /^!(.*)$/
+  }
+  search(text) {
+    const index = text.indexOf(this.pattern);
+    const isMatch = index === -1;
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [0, text.length - 1]
+    }
+  }
+}
+
+// Token: ^file
+
+class PrefixExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'prefix-exact'
+  }
+  static get multiRegex() {
+    return /^\^"(.*)"$/
+  }
+  static get singleRegex() {
+    return /^\^(.*)$/
+  }
+  search(text) {
+    const isMatch = text.startsWith(this.pattern);
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [0, this.pattern.length - 1]
+    }
+  }
+}
+
+// Token: !^fire
+
+class InversePrefixExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'inverse-prefix-exact'
+  }
+  static get multiRegex() {
+    return /^!\^"(.*)"$/
+  }
+  static get singleRegex() {
+    return /^!\^(.*)$/
+  }
+  search(text) {
+    const isMatch = !text.startsWith(this.pattern);
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [0, text.length - 1]
+    }
+  }
+}
+
+// Token: .file$
+
+class SuffixExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'suffix-exact'
+  }
+  static get multiRegex() {
+    return /^"(.*)"\$$/
+  }
+  static get singleRegex() {
+    return /^(.*)\$$/
+  }
+  search(text) {
+    const isMatch = text.endsWith(this.pattern);
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [text.length - this.pattern.length, text.length - 1]
+    }
+  }
+}
+
+// Token: !.file$
+
+class InverseSuffixExactMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'inverse-suffix-exact'
+  }
+  static get multiRegex() {
+    return /^!"(.*)"\$$/
+  }
+  static get singleRegex() {
+    return /^!(.*)\$$/
+  }
+  search(text) {
+    const isMatch = !text.endsWith(this.pattern);
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices: [0, text.length - 1]
+    }
+  }
+}
+
+class FuzzyMatch extends BaseMatch {
+  constructor(
+    pattern,
+    {
+      location = Config.location,
+      threshold = Config.threshold,
+      distance = Config.distance,
+      includeMatches = Config.includeMatches,
+      findAllMatches = Config.findAllMatches,
+      minMatchCharLength = Config.minMatchCharLength,
+      isCaseSensitive = Config.isCaseSensitive,
+      ignoreDiacritics = Config.ignoreDiacritics,
+      ignoreLocation = Config.ignoreLocation
+    } = {}
+  ) {
+    super(pattern);
+    this._bitapSearch = new BitapSearch(pattern, {
+      location,
+      threshold,
+      distance,
+      includeMatches,
+      findAllMatches,
+      minMatchCharLength,
+      isCaseSensitive,
+      ignoreDiacritics,
+      ignoreLocation
+    });
+  }
+  static get type() {
+    return 'fuzzy'
+  }
+  static get multiRegex() {
+    return /^"(.*)"$/
+  }
+  static get singleRegex() {
+    return /^(.*)$/
+  }
+  search(text) {
+    return this._bitapSearch.searchIn(text)
+  }
+}
+
+// Token: 'file
+
+class IncludeMatch extends BaseMatch {
+  constructor(pattern) {
+    super(pattern);
+  }
+  static get type() {
+    return 'include'
+  }
+  static get multiRegex() {
+    return /^'"(.*)"$/
+  }
+  static get singleRegex() {
+    return /^'(.*)$/
+  }
+  search(text) {
+    let location = 0;
+    let index;
+
+    const indices = [];
+    const patternLen = this.pattern.length;
+
+    // Get all exact matches
+    while ((index = text.indexOf(this.pattern, location)) > -1) {
+      location = index + patternLen;
+      indices.push([index, location - 1]);
+    }
+
+    const isMatch = !!indices.length;
+
+    return {
+      isMatch,
+      score: isMatch ? 0 : 1,
+      indices
+    }
+  }
+}
+
+// ❗Order is important. DO NOT CHANGE.
+const searchers = [
+  ExactMatch,
+  IncludeMatch,
+  PrefixExactMatch,
+  InversePrefixExactMatch,
+  InverseSuffixExactMatch,
+  SuffixExactMatch,
+  InverseExactMatch,
+  FuzzyMatch
+];
+
+const searchersLen = searchers.length;
+
+// Regex to split by spaces, but keep anything in quotes together
+const SPACE_RE = / +(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/;
+const OR_TOKEN = '|';
+
+// Return a 2D array representation of the query, for simpler parsing.
+// Example:
+// "^core go$ | rb$ | py$ xy$" => [["^core", "go$"], ["rb$"], ["py$", "xy$"]]
+function parseQuery(pattern, options = {}) {
+  return pattern.split(OR_TOKEN).map((item) => {
+    let query = item
+      .trim()
+      .split(SPACE_RE)
+      .filter((item) => item && !!item.trim());
+
+    let results = [];
+    for (let i = 0, len = query.length; i < len; i += 1) {
+      const queryItem = query[i];
+
+      // 1. Handle multiple query match (i.e, once that are quoted, like `"hello world"`)
+      let found = false;
+      let idx = -1;
+      while (!found && ++idx < searchersLen) {
+        const searcher = searchers[idx];
+        let token = searcher.isMultiMatch(queryItem);
+        if (token) {
+          results.push(new searcher(token, options));
+          found = true;
+        }
+      }
+
+      if (found) {
+        continue
+      }
+
+      // 2. Handle single query matches (i.e, once that are *not* quoted)
+      idx = -1;
+      while (++idx < searchersLen) {
+        const searcher = searchers[idx];
+        let token = searcher.isSingleMatch(queryItem);
+        if (token) {
+          results.push(new searcher(token, options));
+          break
+        }
+      }
+    }
+
+    return results
+  })
+}
+
+// These extended matchers can return an array of matches, as opposed
+// to a singl match
+const MultiMatchSet = new Set([FuzzyMatch.type, IncludeMatch.type]);
+
+/**
+ * Command-like searching
+ * ======================
+ *
+ * Given multiple search terms delimited by spaces.e.g. `^jscript .python$ ruby !java`,
+ * search in a given text.
+ *
+ * Search syntax:
+ *
+ * | Token       | Match type                 | Description                            |
+ * | ----------- | -------------------------- | -------------------------------------- |
+ * | `jscript`   | fuzzy-match                | Items that fuzzy match `jscript`       |
+ * | `=scheme`   | exact-match                | Items that are `scheme`                |
+ * | `'python`   | include-match              | Items that include `python`            |
+ * | `!ruby`     | inverse-exact-match        | Items that do not include `ruby`       |
+ * | `^java`     | prefix-exact-match         | Items that start with `java`           |
+ * | `!^earlang` | inverse-prefix-exact-match | Items that do not start with `earlang` |
+ * | `.js$`      | suffix-exact-match         | Items that end with `.js`              |
+ * | `!.go$`     | inverse-suffix-exact-match | Items that do not end with `.go`       |
+ *
+ * A single pipe character acts as an OR operator. For example, the following
+ * query matches entries that start with `core` and end with either`go`, `rb`,
+ * or`py`.
+ *
+ * ```
+ * ^core go$ | rb$ | py$
+ * ```
+ */
+class ExtendedSearch {
+  constructor(
+    pattern,
+    {
+      isCaseSensitive = Config.isCaseSensitive,
+      ignoreDiacritics = Config.ignoreDiacritics,
+      includeMatches = Config.includeMatches,
+      minMatchCharLength = Config.minMatchCharLength,
+      ignoreLocation = Config.ignoreLocation,
+      findAllMatches = Config.findAllMatches,
+      location = Config.location,
+      threshold = Config.threshold,
+      distance = Config.distance
+    } = {}
+  ) {
+    this.query = null;
+    this.options = {
+      isCaseSensitive,
+      ignoreDiacritics,
+      includeMatches,
+      minMatchCharLength,
+      findAllMatches,
+      ignoreLocation,
+      location,
+      threshold,
+      distance
+    };
+
+    pattern = isCaseSensitive ? pattern : pattern.toLowerCase();
+    pattern = ignoreDiacritics ? stripDiacritics(pattern) : pattern;
+    this.pattern = pattern;
+    this.query = parseQuery(this.pattern, this.options);
+  }
+
+  static condition(_, options) {
+    return options.useExtendedSearch
+  }
+
+  searchIn(text) {
+    const query = this.query;
+
+    if (!query) {
+      return {
+        isMatch: false,
+        score: 1
+      }
+    }
+
+    const { includeMatches, isCaseSensitive, ignoreDiacritics } = this.options;
+
+    text = isCaseSensitive ? text : text.toLowerCase();
+    text = ignoreDiacritics ? stripDiacritics(text) : text;
+
+    let numMatches = 0;
+    let allIndices = [];
+    let totalScore = 0;
+
+    // ORs
+    for (let i = 0, qLen = query.length; i < qLen; i += 1) {
+      const searchers = query[i];
+
+      // Reset indices
+      allIndices.length = 0;
+      numMatches = 0;
+
+      // ANDs
+      for (let j = 0, pLen = searchers.length; j < pLen; j += 1) {
+        const searcher = searchers[j];
+        const { isMatch, indices, score } = searcher.search(text);
+
+        if (isMatch) {
+          numMatches += 1;
+          totalScore += score;
+          if (includeMatches) {
+            const type = searcher.constructor.type;
+            if (MultiMatchSet.has(type)) {
+              allIndices = [...allIndices, ...indices];
+            } else {
+              allIndices.push(indices);
+            }
+          }
+        } else {
+          totalScore = 0;
+          numMatches = 0;
+          allIndices.length = 0;
+          break
+        }
+      }
+
+      // OR condition, so if TRUE, return
+      if (numMatches) {
+        let result = {
+          isMatch: true,
+          score: totalScore / numMatches
+        };
+
+        if (includeMatches) {
+          result.indices = allIndices;
+        }
+
+        return result
+      }
+    }
+
+    // Nothing was matched
+    return {
+      isMatch: false,
+      score: 1
+    }
+  }
+}
+
+const registeredSearchers = [];
+
+function register(...args) {
+  registeredSearchers.push(...args);
+}
+
+function createSearcher(pattern, options) {
+  for (let i = 0, len = registeredSearchers.length; i < len; i += 1) {
+    let searcherClass = registeredSearchers[i];
+    if (searcherClass.condition(pattern, options)) {
+      return new searcherClass(pattern, options)
+    }
+  }
+
+  return new BitapSearch(pattern, options)
+}
+
+const LogicalOperator = {
+  AND: '$and',
+  OR: '$or'
+};
+
+const KeyType = {
+  PATH: '$path',
+  PATTERN: '$val'
+};
+
+const isExpression = (query) =>
+  !!(query[LogicalOperator.AND] || query[LogicalOperator.OR]);
+
+const isPath = (query) => !!query[KeyType.PATH];
+
+const isLeaf = (query) =>
+  !isArray(query) && isObject(query) && !isExpression(query);
+
+const convertToExplicit = (query) => ({
+  [LogicalOperator.AND]: Object.keys(query).map((key) => ({
+    [key]: query[key]
+  }))
+});
+
+// When `auto` is `true`, the parse function will infer and initialize and add
+// the appropriate `Searcher` instance
+function parse(query, options, { auto = true } = {}) {
+  const next = (query) => {
+    let keys = Object.keys(query);
+
+    const isQueryPath = isPath(query);
+
+    if (!isQueryPath && keys.length > 1 && !isExpression(query)) {
+      return next(convertToExplicit(query))
+    }
+
+    if (isLeaf(query)) {
+      const key = isQueryPath ? query[KeyType.PATH] : keys[0];
+
+      const pattern = isQueryPath ? query[KeyType.PATTERN] : query[key];
+
+      if (!isString(pattern)) {
+        throw new Error(LOGICAL_SEARCH_INVALID_QUERY_FOR_KEY(key))
+      }
+
+      const obj = {
+        keyId: createKeyId(key),
+        pattern
+      };
+
+      if (auto) {
+        obj.searcher = createSearcher(pattern, options);
+      }
+
+      return obj
+    }
+
+    let node = {
+      children: [],
+      operator: keys[0]
+    };
+
+    keys.forEach((key) => {
+      const value = query[key];
+
+      if (isArray(value)) {
+        value.forEach((item) => {
+          node.children.push(next(item));
+        });
+      }
+    });
+
+    return node
+  };
+
+  if (!isExpression(query)) {
+    query = convertToExplicit(query);
+  }
+
+  return next(query)
+}
+
+// Practical scoring function
+function computeScore(
+  results,
+  { ignoreFieldNorm = Config.ignoreFieldNorm }
+) {
+  results.forEach((result) => {
+    let totalScore = 1;
+
+    result.matches.forEach(({ key, norm, score }) => {
+      const weight = key ? key.weight : null;
+
+      totalScore *= Math.pow(
+        score === 0 && weight ? Number.EPSILON : score,
+        (weight || 1) * (ignoreFieldNorm ? 1 : norm)
+      );
+    });
+
+    result.score = totalScore;
+  });
+}
+
+function transformMatches(result, data) {
+  const matches = result.matches;
+  data.matches = [];
+
+  if (!isDefined(matches)) {
+    return
+  }
+
+  matches.forEach((match) => {
+    if (!isDefined(match.indices) || !match.indices.length) {
+      return
+    }
+
+    const { indices, value } = match;
+
+    let obj = {
+      indices,
+      value
+    };
+
+    if (match.key) {
+      obj.key = match.key.src;
+    }
+
+    if (match.idx > -1) {
+      obj.refIndex = match.idx;
+    }
+
+    data.matches.push(obj);
+  });
+}
+
+function transformScore(result, data) {
+  data.score = result.score;
+}
+
+function format(
+  results,
+  docs,
+  {
+    includeMatches = Config.includeMatches,
+    includeScore = Config.includeScore
+  } = {}
+) {
+  const transformers = [];
+
+  if (includeMatches) transformers.push(transformMatches);
+  if (includeScore) transformers.push(transformScore);
+
+  return results.map((result) => {
+    const { idx } = result;
+
+    const data = {
+      item: docs[idx],
+      refIndex: idx
+    };
+
+    if (transformers.length) {
+      transformers.forEach((transformer) => {
+        transformer(result, data);
+      });
+    }
+
+    return data
+  })
+}
+
+class Fuse {
+  constructor(docs, options = {}, index) {
+    this.options = { ...Config, ...options };
+
+    if (
+      this.options.useExtendedSearch &&
+      !true
+    ) {
+      throw new Error(EXTENDED_SEARCH_UNAVAILABLE)
+    }
+
+    this._keyStore = new KeyStore(this.options.keys);
+
+    this.setCollection(docs, index);
+  }
+
+  setCollection(docs, index) {
+    this._docs = docs;
+
+    if (index && !(index instanceof FuseIndex)) {
+      throw new Error(INCORRECT_INDEX_TYPE)
+    }
+
+    this._myIndex =
+      index ||
+      createIndex(this.options.keys, this._docs, {
+        getFn: this.options.getFn,
+        fieldNormWeight: this.options.fieldNormWeight
+      });
+  }
+
+  add(doc) {
+    if (!isDefined(doc)) {
+      return
+    }
+
+    this._docs.push(doc);
+    this._myIndex.add(doc);
+  }
+
+  remove(predicate = (/* doc, idx */) => false) {
+    const results = [];
+
+    for (let i = 0, len = this._docs.length; i < len; i += 1) {
+      const doc = this._docs[i];
+      if (predicate(doc, i)) {
+        this.removeAt(i);
+        i -= 1;
+        len -= 1;
+
+        results.push(doc);
+      }
+    }
+
+    return results
+  }
+
+  removeAt(idx) {
+    this._docs.splice(idx, 1);
+    this._myIndex.removeAt(idx);
+  }
+
+  getIndex() {
+    return this._myIndex
+  }
+
+  search(query, { limit = -1 } = {}) {
+    const {
+      includeMatches,
+      includeScore,
+      shouldSort,
+      sortFn,
+      ignoreFieldNorm
+    } = this.options;
+
+    let results = isString(query)
+      ? isString(this._docs[0])
+        ? this._searchStringList(query)
+        : this._searchObjectList(query)
+      : this._searchLogical(query);
+
+    computeScore(results, { ignoreFieldNorm });
+
+    if (shouldSort) {
+      results.sort(sortFn);
+    }
+
+    if (isNumber(limit) && limit > -1) {
+      results = results.slice(0, limit);
+    }
+
+    return format(results, this._docs, {
+      includeMatches,
+      includeScore
+    })
+  }
+
+  _searchStringList(query) {
+    const searcher = createSearcher(query, this.options);
+    const { records } = this._myIndex;
+    const results = [];
+
+    // Iterate over every string in the index
+    records.forEach(({ v: text, i: idx, n: norm }) => {
+      if (!isDefined(text)) {
+        return
+      }
+
+      const { isMatch, score, indices } = searcher.searchIn(text);
+
+      if (isMatch) {
+        results.push({
+          item: text,
+          idx,
+          matches: [{ score, value: text, norm, indices }]
+        });
+      }
+    });
+
+    return results
+  }
+
+  _searchLogical(query) {
+
+    const expression = parse(query, this.options);
+
+    const evaluate = (node, item, idx) => {
+      if (!node.children) {
+        const { keyId, searcher } = node;
+
+        const matches = this._findMatches({
+          key: this._keyStore.get(keyId),
+          value: this._myIndex.getValueForItemAtKeyId(item, keyId),
+          searcher
+        });
+
+        if (matches && matches.length) {
+          return [
+            {
+              idx,
+              item,
+              matches
+            }
+          ]
+        }
+
+        return []
+      }
+
+      const res = [];
+      for (let i = 0, len = node.children.length; i < len; i += 1) {
+        const child = node.children[i];
+        const result = evaluate(child, item, idx);
+        if (result.length) {
+          res.push(...result);
+        } else if (node.operator === LogicalOperator.AND) {
+          return []
+        }
+      }
+      return res
+    };
+
+    const records = this._myIndex.records;
+    const resultMap = {};
+    const results = [];
+
+    records.forEach(({ $: item, i: idx }) => {
+      if (isDefined(item)) {
+        let expResults = evaluate(expression, item, idx);
+
+        if (expResults.length) {
+          // Dedupe when adding
+          if (!resultMap[idx]) {
+            resultMap[idx] = { idx, item, matches: [] };
+            results.push(resultMap[idx]);
+          }
+          expResults.forEach(({ matches }) => {
+            resultMap[idx].matches.push(...matches);
+          });
+        }
+      }
+    });
+
+    return results
+  }
+
+  _searchObjectList(query) {
+    const searcher = createSearcher(query, this.options);
+    const { keys, records } = this._myIndex;
+    const results = [];
+
+    // List is Array<Object>
+    records.forEach(({ $: item, i: idx }) => {
+      if (!isDefined(item)) {
+        return
+      }
+
+      let matches = [];
+
+      // Iterate over every key (i.e, path), and fetch the value at that key
+      keys.forEach((key, keyIndex) => {
+        matches.push(
+          ...this._findMatches({
+            key,
+            value: item[keyIndex],
+            searcher
+          })
+        );
+      });
+
+      if (matches.length) {
+        results.push({
+          idx,
+          item,
+          matches
+        });
+      }
+    });
+
+    return results
+  }
+  _findMatches({ key, value, searcher }) {
+    if (!isDefined(value)) {
+      return []
+    }
+
+    let matches = [];
+
+    if (isArray(value)) {
+      value.forEach(({ v: text, i: idx, n: norm }) => {
+        if (!isDefined(text)) {
+          return
+        }
+
+        const { isMatch, score, indices } = searcher.searchIn(text);
+
+        if (isMatch) {
+          matches.push({
+            score,
+            key,
+            value: text,
+            idx,
+            norm,
+            indices
+          });
+        }
+      });
+    } else {
+      const { v: text, n: norm } = value;
+
+      const { isMatch, score, indices } = searcher.searchIn(text);
+
+      if (isMatch) {
+        matches.push({ score, key, value: text, norm, indices });
+      }
+    }
+
+    return matches
+  }
+}
+
+Fuse.version = '7.1.0';
+Fuse.createIndex = createIndex;
+Fuse.parseIndex = parseIndex;
+Fuse.config = Config;
+
+{
+  Fuse.parseQuery = parse;
+}
+
+{
+  register(ExtendedSearch);
+}
+
+export { Fuse as default };


### PR DESCRIPTION
# Why
As part of our effort to enhance the experience for solo users (and even small teams sharing same workspace!) on the FREE Edition, we're introducing a more intuitive way to manage complex projects. With this feature, we're adding an instant issue search to the Workflow Board, making it easier to find issues quickly by title and labels.

# Description
We can now filter issues/cards by their title and labels using a single text input field. The search is fuzzy, case-insensitive, ignores accentuation and word order. This makes searching more flexible and user-friendly. 

# Changes
- Introduces fuse.js to handle fuzzy search.
- Implements a new issue_filtering_controller.js Stimulus controller for filtering issues.
- The show/hide behavior is managed via a data-is-issue-search-match attribute and CSS.
- UI tweaks to the board, making it more compact.
- Updates the label helper to provide a default text/border color, with an empty placeholder for future label color customization.
- Refactored: Removed the nested context "Managing Tags" from spec/features/project_management/kanban/managing_issues_data_spec.rb.

# Demo
![board-search](https://github.com/user-attachments/assets/54cd8b24-ab58-409c-9bf9-9d54f5a5a038)
