### PR TITLE
fix(select2): hiding selected option from search result

### DIFF
--- a/app/assets/tailwind/themes/select2.css
+++ b/app/assets/tailwind/themes/select2.css
@@ -4,9 +4,6 @@
 .select2-dropdown {
   font-size: 14px !important;
 }
-.select2-container--default .select2-results__option[aria-selected=true] {
-  display: none !important;
-}
 
 .select2-container--open {
   z-index: 9999999

--- a/app/javascript/controllers/select2_controller.js
+++ b/app/javascript/controllers/select2_controller.js
@@ -4,6 +4,20 @@ export default class extends Controller {
   initialize() {
     this.select2 = $(this.element).select2({
       placeholder: this.element.getAttribute('placeholder'),
+      matcher: (params, data) => {
+        // If there are no search terms, return all options
+        if ($.trim(params.term) === '') {
+          return data;
+        }
+
+        // Do not show selected options in the search results
+        if ($(this.element).val().includes(data.id.toString())) {
+          return null;
+        }
+
+        // Apply default matching logic
+        return $.fn.select2.defaults.defaults.matcher(params, data);
+      },
       width: '100%',
       tags: (this.element.dataset.tags == "true")
     });


### PR DESCRIPTION
This PR fixes the select2 custom behavior to hide selected options from search result list. 

The old implementation was buggy because It was hiding options that were not really selected yet because the `aria-selected` is applied to a 'focused' option while navigating through the search result list. 

This was also causing some specs to fail.

In order to solve this, we need to intercept the original search matcher to ignore already selected options 