### PR TITLE
Refactory: Channel stream formats

### DIFF
--- a/app/channels/visualizations/allocations_channel.rb
+++ b/app/channels/visualizations/allocations_channel.rb
@@ -2,14 +2,14 @@ class Visualizations::AllocationsChannel < ApplicationCable::Channel
   class << self
     def broadcast_update(allocation)
       visualization_id = allocation.grouping.visualization_id
-      broadcard(
+      broadcast(
         "visualizations:#{visualization_id}:allocations#update",
         allocation
       )
     end
 
     private
-    def broadcard(stream_id, payload)
+    def broadcast(stream_id, payload)
       ActionCable.server.broadcast(stream_id, payload)
     end
   end

--- a/app/channels/visualizations/allocations_channel.rb
+++ b/app/channels/visualizations/allocations_channel.rb
@@ -1,10 +1,20 @@
 class Visualizations::AllocationsChannel < ApplicationCable::Channel
-  def self.broadcast_update(allocation)
-    visualization_id = allocation.grouping.visualization_id
-    ActionCable.server.broadcast("visualizations/#{visualization_id}/allocations/updated", allocation)
+  class << self
+    def broadcast_update(allocation)
+      visualization_id = allocation.grouping.visualization_id
+      broadcard(
+        "visualizations:#{visualization_id}:allocations#update",
+        allocation
+      )
+    end
+
+    private
+    def broadcard(stream_id, payload)
+      ActionCable.server.broadcast(stream_id, payload)
+    end
   end
 
   def subscribed
-    stream_from "visualizations/#{params[:visualization_id]}/allocations/updated"
+    stream_from "visualizations:#{params[:visualization_id]}:allocations##{params[:action]}"
   end
 end

--- a/app/channels/visualizations/groupings_channel.rb
+++ b/app/channels/visualizations/groupings_channel.rb
@@ -1,14 +1,14 @@
 class Visualizations::GroupingsChannel < ApplicationCable::Channel
   class << self
     def broadcast_update(grouping)
-      broadcard(
+      broadcast(
         "visualizations:#{grouping.visualization_id}:groupings#update",
         grouping
       )
     end
 
     private
-    def broadcard(stream_id, payload)
+    def broadcast(stream_id, payload)
       ActionCable.server.broadcast(stream_id, payload)
     end
   end

--- a/app/channels/visualizations/groupings_channel.rb
+++ b/app/channels/visualizations/groupings_channel.rb
@@ -1,12 +1,19 @@
 class Visualizations::GroupingsChannel < ApplicationCable::Channel
-  def self.broadcast_update(grouping)
-    ActionCable.server.broadcast(
-      "visualizations/#{grouping.visualization_id}/groupings/updated",
-      grouping
-    )
+  class << self
+    def broadcast_update(grouping)
+      broadcard(
+        "visualizations:#{grouping.visualization_id}:groupings#update",
+        grouping
+      )
+    end
+
+    private
+    def broadcard(stream_id, payload)
+      ActionCable.server.broadcast(stream_id, payload)
+    end
   end
 
   def subscribed
-    stream_from "visualizations/#{params[:visualization_id]}/groupings/updated"
+    stream_from "visualizations:#{params[:visualization_id]}:groupings##{params[:action]}"
   end
 end

--- a/app/javascript/controllers/visualization/board_controller.js
+++ b/app/javascript/controllers/visualization/board_controller.js
@@ -15,22 +15,24 @@ export default class extends Controller {
   #subscribeToGroupings() {
     return consumer.subscriptions.create({
       channel: "Visualizations::GroupingsChannel",
-      visualization_id: this.visualizationIdValue
+      visualization_id: this.visualizationIdValue,
+      action: 'update'
     }, {
-      received: this.onGroupingMove.bind(this)
+      received: this.onGroupingUpdate.bind(this)
     })
   }
 
   #subscribeToAllocations() {
     return consumer.subscriptions.create({
       channel: "Visualizations::AllocationsChannel",
-      visualization_id: this.visualizationIdValue
+      visualization_id: this.visualizationIdValue,
+      action: 'update'
     }, {
       received: this.onCardMove.bind(this)
     })
   }
 
-  onGroupingMove({ id, position }) {
+  onGroupingUpdate({ id, position }) {
     const movingColumn = this.#findColumnByGroupingId(id)
     const movingColumnCurrentPosition = this.columnTargets.indexOf(movingColumn)
     const movingColumnNewPosition = position - 1 // Positioning gem use indexes starting on 1

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -37,7 +37,7 @@ class Grouping < ApplicationRecord
   }, unless: :saved_change_to_position?
   after_update_commit -> {
     Visualizations::GroupingsChannel.broadcast_update(self)
-  }, if: :saved_change_to_position?
+  }
   after_destroy_commit -> { broadcast_remove_to visualization }
 
   def allocate_issue(issue)


### PR DESCRIPTION
## Why?

As discussed [here](https://github.com/Eigenfocus/eigenfocus/pull/43#discussion_r1943709340), our initial channel implementation could be improved by making the stream id more flexible by accepting the action that the consumer is subscribing to, for example:

```rb
"visualizations:123:groupings#update"
```

Also, by interpolating a params to this format, the client can easily choose to subscribe to more than one action in the same channel too.

## How

- Change stream id namespace separator from `/` to `:`
- Add action as part of the subscription params and using on the stream id
- Change model callbacks to always broadcast on update, as it is not binded to the "move" concept anymore