### PR TITLE
WIP: feat: UI improvements and and refactors for Issues visualizations

### DIFF
--- a/app/assets/tailwind/themes/_components/all.css
+++ b/app/assets/tailwind/themes/_components/all.css
@@ -1,0 +1,1 @@
+@import "./table"

--- a/app/assets/tailwind/themes/_components/all.css
+++ b/app/assets/tailwind/themes/_components/all.css
@@ -1,1 +1,3 @@
-@import "./table"
+@import "./table";
+@import "./button";
+@import "./link";

--- a/app/assets/tailwind/themes/_components/button.css
+++ b/app/assets/tailwind/themes/_components/button.css
@@ -1,0 +1,36 @@
+
+.btn .loading-spinner,
+.btn-primary .loading-spinner,
+.btn-secondary .loading-spinner,
+.btn-tertiary .loading-spinner {
+  width: 0;
+  overflow: hidden;
+  transition: width 400ms linear;
+}
+
+.btn[disabled] .loading-spinner,
+.btn-primary[disabled] .loading-spinner,
+.btn-secondary[disabled] .loading-spinner,
+.btn-tertiary[disabled] .loading-spinner  {
+  @apply w-5 -ml-1 mr-3 -ml-1 h-5 animate-spin;
+}
+
+.btn.btn-sm[disabled] .loading-spinner {
+  @apply w-3 h-3 mr-2;
+}
+
+.btn.btn-sm {
+  @apply py-1 px-2 text-xs h-7;
+}
+
+.btn.btn-md {
+  @apply py-1 px-2 text-sm h-9;
+}
+
+.btn-primary.btn-xl,
+.btn-secondary.btn-xl,
+.btn-tertiary.btn-xl,
+.btn-danger.btn-xl,
+.btn-cancel.btn-xl {
+  @apply py-4;
+}

--- a/app/assets/tailwind/themes/_components/link.css
+++ b/app/assets/tailwind/themes/_components/link.css
@@ -1,0 +1,20 @@
+
+.link-base {
+  @apply font-medium no-underline transition-colors;
+}
+
+.link-primary {
+  @apply link-base	text-primary-500 hover:text-primary-700 active:text-primary-700 focus:text-primary-700 visited:text-primary-700;
+}
+
+.link-secondary {
+  @apply link-base	text-secondary-500 hover:text-secondary-700 active:text-secondary-700 focus:text-secondary-700 visited:text-secondary-700;
+}
+
+.link-tertiary {
+  @apply link-base text-tertiary-500 hover:text-tertiary-700 active:text-tertiary-700 focus:text-tertiary-700 visited:text-tertiary-700;
+}
+
+.link-danger {
+  @apply link-base text-danger-500 hover:text-danger-700 active:text-danger-700 focus:text-danger-700 visited:text-danger-700;
+}

--- a/app/assets/tailwind/themes/_components/table.css
+++ b/app/assets/tailwind/themes/_components/table.css
@@ -1,0 +1,39 @@
+
+.table-primary {
+  @apply text-left w-full border-collapse;
+}
+
+.table-primary thead th {
+  @apply whitespace-nowrap bg-readable-content-200 first:pl-5 last:pr-5 py-3 font-medium text-xs uppercase text-readable-content-500;
+}
+
+.table-primary thead th:first-child {
+  @apply rounded-tl-lg;
+}
+
+.table-primary thead th:last-child {
+  @apply rounded-tr-lg;
+}
+
+.table-primary tbody tr {
+  @apply border-b border-readable-content-200 hover:bg-readable-content-50 bg-body-contrast;
+}
+.table-primary tbody tr.inactive-row {
+  @apply bg-readable-content-50;
+}
+
+.table-primary.table-striped tbody tr:nth-child(odd) {
+  @apply bg-readable-content-50 hover:bg-readable-content-100;
+}
+
+.table-primary.table-striped tbody tr:nth-child(even) {
+  @apply bg-body-contrast hover:bg-readable-content-100;
+}
+
+.table-primary tbody tr:last-child {
+  @apply border-0;
+}
+
+.table-primary tbody tr td {
+  @apply first:pl-5 last:pr-5 py-3;
+}

--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -14,58 +14,6 @@
   display: none;
 }
 
-.btn .loading-spinner,
-.btn-primary .loading-spinner,
-.btn-secondary .loading-spinner,
-.btn-tertiary .loading-spinner {
-  width: 0;
-  overflow: hidden;
-  transition: width 400ms linear;
-}
-
-.btn[disabled] .loading-spinner,
-.btn-primary[disabled] .loading-spinner,
-.btn-secondary[disabled] .loading-spinner,
-.btn-tertiary[disabled] .loading-spinner  {
-  @apply w-5 -ml-1 mr-3 -ml-1 h-5 animate-spin;
-}
-
-.btn.btn-sm[disabled] .loading-spinner {
-  @apply w-3 h-3 mr-2;
-}
-
-.btn.btn-sm {
-  @apply py-1 px-2 text-xs h-7;
-}
-
-.btn.btn-md {
-  @apply py-1 px-2 text-sm h-9;
-}
-
-.btn-primary.btn-xl,
-.btn-secondary.btn-xl,
-.btn-tertiary.btn-xl,
-.btn-danger.btn-xl,
-.btn-cancel.btn-xl {
-  @apply py-4;
-}
-
-.link-base {
-  @apply font-medium no-underline transition-colors;
-}
-
-.link-primary {
-  @apply link-base	text-primary-500 hover:text-primary-700 active:text-primary-700 focus:text-primary-700 visited:text-primary-700;
-}
-
-.link-secondary {
-  @apply link-base	text-secondary-500 hover:text-secondary-700 active:text-secondary-700 focus:text-secondary-700 visited:text-secondary-700;
-}
-
-.link-tertiary {
-  @apply link-base text-tertiary-500 hover:text-tertiary-700 active:text-tertiary-700 focus:text-tertiary-700 visited:text-tertiary-700;
-}
-
 .card {
   @apply p-5 bg-body-contrast border border-primary-100 rounded-sm shadow-sm;
 }
@@ -75,7 +23,6 @@ input.input-primary,
 .flatpickr-input.input-primary {
   @apply w-full rounded-lg border border-background-300 px-3 bg-background-50 text-readable-content-500 py-2 placeholder:text-readable-content-400/70 hover:border-background-400 focus:border-primary-500;
 }
-
 
 .input-contrast,
 input.input-contrast,

--- a/app/assets/tailwind/themes/base.css
+++ b/app/assets/tailwind/themes/base.css
@@ -3,6 +3,7 @@
 @import './markdown';
 @import './sortablejs';
 @import './pagy.tailwind';
+@import './_components/all';
 
 /* :empty does't work if element has any text */
 .hide-if-empty:not(:has(:first-child)) {
@@ -67,62 +68,6 @@
 
 .card {
   @apply p-5 bg-body-contrast border border-primary-100 rounded-sm shadow-sm;
-}
-
-.table-primary {
-  @apply text-left w-full border-collapse;
-}
-
-.table-primary thead th {
-  @apply whitespace-nowrap bg-background-200 px-3 py-3 font-medium text-sm uppercase text-readable-content-500 lg:px-5;
-}
-
-.table-primary.table-md thead th {
-  @apply px-2 py-2 text-sm;
-}
-
-.table-primary.table-compact thead th {
-  @apply px-1 py-2 text-xs;
-}
-
-.table-primary thead th:first-child {
-  @apply rounded-tl-lg;
-}
-
-.table-primary thead th:last-child {
-  @apply rounded-tr-lg;
-}
-
-.table-primary tbody tr {
-  @apply border-y border-b-background-200 hover:bg-background-50 bg-body-contrast;
-}
-.table-primary tbody tr.inactive-row {
-  @apply bg-background-50;
-}
-
-.table-primary.table-striped tbody tr:nth-child(odd) {
-  @apply bg-background-50 hover:bg-background-100;
-}
-
-.table-primary.table-striped tbody tr:nth-child(even) {
-  @apply bg-body-contrast hover:bg-background-100;
-}
-
-.table-primary tbody tr:last-child {
-  @apply border-0;
-}
-
-.table-primary tbody tr td {
-  @apply py-4 px-2 md:px-6 2xl:px-7;
-}
-
-.table-primary.table-md tr td {
-  @apply py-2 px-2 text-sm;
-}
-
-
-.table-primary.table-compact tr td {
-  @apply py-1 px-1 text-xs;
 }
 
 .input-primary,

--- a/app/assets/tailwind/themes/select2.css
+++ b/app/assets/tailwind/themes/select2.css
@@ -23,6 +23,11 @@
   min-height: 43px;
 }
 
+.select2-sm .select2-selection.select2-selection--multiple,
+.select2-sm .select2-selection.select2-selection--single {
+  min-height: 34px;
+}
+
 .select2-contrast .select2-selection {
   @apply bg-body-contrast !important;
 }

--- a/app/assets/tailwind/themes/select2.css
+++ b/app/assets/tailwind/themes/select2.css
@@ -23,6 +23,10 @@
   min-height: 43px;
 }
 
+.select2-contrast .select2-selection {
+  @apply bg-body-contrast !important;
+}
+
 .select2-container--default.select2-container--focus .select2-selection--multiple,
 .select2-container--default .select2-selection--single {
   @apply border border-background-300;
@@ -53,6 +57,11 @@
 
 .select2-container--default .select2-search--dropdown .select2-search__field {
   @apply input-primary border-background-400 !important;
+}
+
+.select2-container--default.select2-contrast .select2-search--inline .select2-search__field,
+.select2-container--defaultt.select2-contrast .select2-search--dropdown .select2-search__field  {
+  @apply bg-body-contrast !important;
 }
 
 .select2-container--default .select2-selection--single .select2-selection__rendered {

--- a/app/javascript/controllers/select2_controller.js
+++ b/app/javascript/controllers/select2_controller.js
@@ -22,6 +22,10 @@ export default class extends Controller {
       tags: (this.element.dataset.tags == "true")
     });
 
+    if (this.element.dataset.select2AdditionalClasses) {
+      this.select2.data('select2').$container.addClass(this.element.dataset.select2AdditionalClasses);
+    }
+
     this.select2.on('select2:select', function () {
       let event = new Event('change', { bubbles: true }) // fire a native event
       this.dispatchEvent(event);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,7 +53,7 @@
          <% if skip_layout_content_wrapper? %>
           <%= yield %>
          <% else %>
-          <main class="grow p-4 sm:p-12">
+          <main class="grow p-4 sm:p-8">
             <%= yield %>
           </main>
         <% end %>

--- a/app/views/projects/_navigation_header.html.erb
+++ b/app/views/projects/_navigation_header.html.erb
@@ -9,13 +9,27 @@
       <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
     <% end %>
   </div>
-  </div>
-<div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
-  <%= link_to project_issues_path(project), class: "px-2 pb-1 whitespace-nowrap" do %>
-    <%= t(:all_issues, scope: :nav) %>
-  <% end %>
+</div>
+<div class="mt-2 mb-4 flex gap-4 text-sm font-medium border-b border-readable-content-300">
+  <%
+    default_classes = "px-2 pb-1 whitespace-nowrap"
+    tabs = [{
+        text: t(:all_issues, scope: :nav),
+        options: { href: project_issues_path(project) },
+        is_selected: controller_name.downcase == 'issues'
+      },{
+        text: t(:board_view, scope: :nav),
+        options: { href: visualization_path(project.default_visualization) },
+        is_selected: controller_name.downcase == 'visualizations'
+      }
+    ].each do |tab|
 
-  <%= link_to visualization_path(project.default_visualization), class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
-    <%= t(:board_view, scope: :nav) %>
+    tab[:options][:class] = "px-2 pb-1 whitespace-nowrap"
+
+    if tab[:is_selected]
+      tab[:options][:class] += "border-b-2 border-primary-500 text-primary-500"
+    end
+  %>
+    <%= content_tag :a, tab[:text], tab[:options] %>
   <% end %>
 </div>

--- a/app/views/projects/_navigation_header.html.erb
+++ b/app/views/projects/_navigation_header.html.erb
@@ -18,7 +18,7 @@
         options: { href: project_issues_path(project) },
         is_selected: controller_name.downcase == 'issues'
       },{
-        text: t(:board_view, scope: :nav),
+        text: Visualization.model_name.human,
         options: { href: visualization_path(project.default_visualization) },
         is_selected: controller_name.downcase == 'visualizations'
       }

--- a/app/views/projects/_navigation_header.html.erb
+++ b/app/views/projects/_navigation_header.html.erb
@@ -1,23 +1,21 @@
-<div class="flex flex-col sm:px-12 pt-4">
-  <div class="flex  items-end justify-between gap-2">
-    <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
-      <%= project.name %>
-    </h2>
+<div class="flex items-end justify-between gap-2">
+  <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
+    <%= project.name %>
+  </h2>
 
-    <div class="flex items-stretch flex-col sm:flex-row gap-4">
-      <%= link_to time_entries_path(new_entry: { project_id: project.id }), class: "flex items-center link-secondary flex", data: { turbo_frame: "_top" } do %>
-        <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
-        <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
-      <% end %>
-    </div>
-    </div>
-  <div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
-    <%= link_to project_issues_path(project), class: "px-2 pb-1 whitespace-nowrap" do %>
-      <%= t(:all_issues, scope: :nav) %>
-    <% end %>
-
-    <%= link_to visualization_path(project.default_visualization), class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
-      <%= t(:board_view, scope: :nav) %>
+  <div class="flex items-stretch flex-col sm:flex-row gap-4">
+    <%= link_to time_entries_path(new_entry: { project_id: project.id }), class: "flex items-center link-secondary flex", data: { turbo_frame: "_top" } do %>
+      <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
+      <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
     <% end %>
   </div>
+  </div>
+<div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
+  <%= link_to project_issues_path(project), class: "px-2 pb-1 whitespace-nowrap" do %>
+    <%= t(:all_issues, scope: :nav) %>
+  <% end %>
+
+  <%= link_to visualization_path(project.default_visualization), class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
+    <%= t(:board_view, scope: :nav) %>
+  <% end %>
 </div>

--- a/app/views/projects/_navigation_header.html.erb
+++ b/app/views/projects/_navigation_header.html.erb
@@ -1,0 +1,23 @@
+<div class="flex flex-col sm:px-12 pt-4">
+  <div class="flex  items-end justify-between gap-2">
+    <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
+      <%= project.name %>
+    </h2>
+
+    <div class="flex items-stretch flex-col sm:flex-row gap-4">
+      <%= link_to time_entries_path(new_entry: { project_id: project.id }), class: "flex items-center link-secondary flex", data: { turbo_frame: "_top" } do %>
+        <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
+        <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
+      <% end %>
+    </div>
+    </div>
+  <div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
+    <%= link_to project_issues_path(project), class: "px-2 pb-1 whitespace-nowrap" do %>
+      <%= t(:all_issues, scope: :nav) %>
+    <% end %>
+
+    <%= link_to visualization_path(project.default_visualization), class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
+      <%= t(:board_view, scope: :nav) %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,0 +1,37 @@
+<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "mb-8" do |f| %>
+  <div class="flex flex-col md:flex-row justify-start items-start md:items-center gap-4">
+    <div class="flex gap-2 flex-col">
+      <%= f.label :title_cont, class: "text-readable-content-500 font-medium text-xs" %>
+      <div class="input-with-icon-wrapper w-64">
+        <div class="icon-wrapper">
+          <i class="text-readable-content-300 fa fa-search"></i>
+        </div>
+        <%= f.search_field :title_cont, class: 'input-contrast' %>
+      </div>
+    </div>
+
+
+    <div class="flex w-64 gap-2 flex-col">
+      <%= f.label :by_label_titles, class: "text-readable-content-500 font-medium text-xs" %>
+      <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
+                { include_hidden: false },
+                class: 'input-primary input-sm',
+                multiple: true,
+                data: {
+                  controller: 'select2',
+                  "select2-additional-classes": 'select2-contrast'
+                }
+              %>
+    </div>
+
+
+    <div class="mt-4 flex gap-4 items-center">
+      <%= f.submit class: "btn-primary" %>
+
+      <%= link_to project_issues_path(current_project), class: "link-cancel text-sm" do %>
+        <%= t('actions.clear_filter').capitalize %>
+      <% end %>
+    </div>
+
+  </div>
+<% end %>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,12 +1,12 @@
-<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "mb-8" do |f| %>
-  <div class="flex flex-col md:flex-row justify-start items-start md:items-center gap-4">
-    <div class="flex gap-2 items-center">
+<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "mt-8 mb-8" do |f| %>
+  <div class="flex flex-col md:flex-row justify-start items-stretch gap-4">
+    <div class="flex gap-2 w-62 items-center">
       <%= f.label :title_cont, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
       <%= f.search_field :title_cont, class: 'input-contrast input-sm' %>
     </div>
 
 
-    <div class="flex w-64 gap-2 items-center">
+    <div class="flex grow gap-2 items-center">
       <%= f.label :by_label_titles, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
       <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
                 { include_hidden: false },
@@ -20,12 +20,12 @@
     </div>
 
 
-    <div class="flex gap-4 items-center">
-      <%= f.button class: "btn-primary btn-sm flex" do %>
+    <div class="flex gap-4 items-stretch">
+      <%= f.button class: "btn-primary flex items-center " do %>
         <i class="fa fa-search mr-2"></i>
         <%= t(:search, scope: :actions) %>
       <% end %>
-      <%= link_to project_issues_path(current_project), class: "link-cancel text-sm" do %>
+      <%= link_to project_issues_path(current_project), class: "flex items-center text-nowrap link-cancel text-sm" do %>
         <%= t('actions.clear_filter').capitalize %>
       <% end %>
     </div>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,33 +1,30 @@
 <%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "mb-8" do |f| %>
   <div class="flex flex-col md:flex-row justify-start items-start md:items-center gap-4">
-    <div class="flex gap-2 flex-col">
-      <%= f.label :title_cont, class: "text-readable-content-500 font-medium text-xs" %>
-      <div class="input-with-icon-wrapper w-64">
-        <div class="icon-wrapper">
-          <i class="text-readable-content-300 fa fa-search"></i>
-        </div>
-        <%= f.search_field :title_cont, class: 'input-contrast' %>
-      </div>
+    <div class="flex gap-2 items-center">
+      <%= f.label :title_cont, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
+      <%= f.search_field :title_cont, class: 'input-contrast input-sm' %>
     </div>
 
 
-    <div class="flex w-64 gap-2 flex-col">
-      <%= f.label :by_label_titles, class: "text-readable-content-500 font-medium text-xs" %>
+    <div class="flex w-64 gap-2 items-center">
+      <%= f.label :by_label_titles, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
       <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
                 { include_hidden: false },
                 class: 'input-primary input-sm',
                 multiple: true,
                 data: {
                   controller: 'select2',
-                  "select2-additional-classes": 'select2-contrast'
+                  "select2-additional-classes": 'select2-contrast select2-sm'
                 }
               %>
     </div>
 
 
-    <div class="mt-4 flex gap-4 items-center">
-      <%= f.submit class: "btn-primary" %>
-
+    <div class="flex gap-4 items-center">
+      <%= f.button class: "btn-primary btn-sm flex" do %>
+        <i class="fa fa-search mr-2"></i>
+        <%= t(:search, scope: :actions) %>
+      <% end %>
       <%= link_to project_issues_path(current_project), class: "link-cancel text-sm" do %>
         <%= t('actions.clear_filter').capitalize %>
       <% end %>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -7,4 +7,14 @@
   </td>
   <td><%= l issue.created_at, format: :short %></td>
   <td><%= l issue.updated_at, format: :short %></td>
+  <td>
+    <div class="flex gap-4 text-lg opacity-80">
+      <button class="link-base">
+        <i class="fa fa-edit"></i>
+      </button>
+      <button class="link-danger">
+        <i class="fa fa-trash-can"></i>
+      </button>
+    </div>
+  </td>
 </tr>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -6,35 +6,7 @@
 } %>
 
 <%= turbo_frame_tag 'issues', data: { turbo_action: "advance" } do %>
-  <%= search_form_for @q, url: project_issues_path(project_id: current_project.id), class: "bg-body-contrast rounded-md border border-background-200 p-4 space-y-4  mb-6" do |f| %>
-    <div class="flex flex-col w-full justify-stretch items-stretch md:flex-row gap-2">
-      <div class="w-full flex flex-col md:flex-row justify-stretch items-stretch gap-2">
-        <div class="flex grow gap-2 flex-col">
-          <%= f.label :title_cont, class: "text-readable-content-500 text-sm" %>
-          <%= f.search_field :title_cont, class: 'input-primary w-full' %>
-        </div>
-      </div>
-
-      <div class="w-full flex flex-col md:flex-row justify-stretch items-stretch gap-2">
-        <div class="flex grow gap-2 flex-col">
-          <%= f.label :by_label_titles, class: "text-readable-content-500 text-sm" %>
-          <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
-                    { include_blank: true, include_hidden: false },
-                    class: 'input-primary',
-                    multiple: true,
-                    data: { controller: 'select2' }
-                  %>
-        </div>
-      </div>
-    </div>
-
-    <div class="flex items-center justify-end gap-2">
-      <%= link_to project_issues_path(current_project), class: "button-cancel text-sm mr-4" do %>
-        <%= t('actions.clear_filter').capitalize %>
-      <% end %>
-      <%= f.submit class: "btn-primary" %>
-    </div>
-  <% end %>
+  <%= render partial: 'filter', locals: { q: @q } %>
 
   <div class="flex flex-col gap-3 lg:gap-6 flex-wrap justify-stretch">
     <% if @issues.empty? %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -1,5 +1,6 @@
 <% set_page_title(:project_all_issues, project_name: current_project.name) %>
 
+
 <%= render partial: 'projects/navigation_header', locals: {
   project: current_project
 } %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -1,26 +1,8 @@
 <% set_page_title(:project_all_issues, project_name: current_project.name) %>
 
-<div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-  <h2 class="font-semibold text-3xl text-readable-content-800">
-    <%= t(:project_all_issues, scope: :page_title, project_name: current_project.name) %>
-  </h2>
-</div>
-
-<div class="mb-4 relative">
-  <div class="absolute w-full bottom-0 h-px bg-body-contrast" aria-hidden="true"></div>
-  <ul class="relative text-sm font-medium flex flex-nowrap overflow-hidden no-scrollbar">
-    <li class="mr-6">
-      <%= link_to project_issues_path(current_project), class: "block pb-2 border-b-2 border-primary whitespace-nowrap" do %>
-        <%= t(:all_issues, scope: :nav) %>
-      <% end %>
-    </li>
-    <li class="mr-6">
-      <%= link_to visualization_path(current_project.default_visualization), class: "block pb-2 whitespace-nowrap" do %>
-        <%= t(:board_view, scope: :nav) %>
-      <% end %>
-    </li>
-  </ul>
-</div>
+<%= render partial: 'projects/navigation_header', locals: {
+  project: current_project
+} %>
 
 <%= turbo_frame_tag 'issues', data: { turbo_action: "advance" } do %>
   <%= search_form_for @q, url: project_issues_path(project_id: current_project.id), class: "bg-body-contrast rounded-md border border-background-200 p-4 space-y-4  mb-6" do |f| %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -11,7 +11,7 @@
   <div class="flex flex-col gap-3 lg:gap-6 flex-wrap justify-stretch">
     <% if @issues.empty? %>
     <% else %>
-      <table class="table-auto table-primary table-striped">
+      <table class="table-primary table-striped">
         <thead class="text-xs font-semibold uppercase ">
           <tr>
             <th><%= sort_link(@q, :title, Issue.human_attribute_name(:title)) %></th>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -18,6 +18,7 @@
             <th><%= Issue.human_attribute_name(:labels) %></th>
             <th><%= sort_link(@q, :created_at, Issue.human_attribute_name(:created_at)) %></th>
             <th><%= sort_link(@q, :updated_at, Issue.human_attribute_name(:updated_at)) %></th>
+            <th><%= t(:actions, scope: :menu) %></th>
           </tr>
         </thead>
         <tbody class="text-sm divide-y">

--- a/app/views/visualizations/_board_header.html.erb
+++ b/app/views/visualizations/_board_header.html.erb
@@ -1,0 +1,25 @@
+<div class="px-4 sm:px-8 flex justify-between items-center">
+  <div class="flex items-stretch gap-4">
+    <div class="input-with-icon-wrapper w-64">
+      <div class="icon-wrapper">
+        <i class="text-readable-content-300 fa fa-search"></i>
+      </div>
+      <input class="input-contrast input-sm active cpy-issues-search"
+        placeholder="Search issue"
+        data-visualization--issue-filtering-target="searchInput"
+        data-action="input->visualization--issue-filtering#filterIssues"
+        type="search" placeholder="Search…">
+    </div>
+  </div>
+
+  <div class="flex items-stretch flex-col sm:flex-row gap-4">
+    <%= link_to new_visualization_grouping_path(visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
+      <i class="fa-solid fa-plus mr-2"></i>
+
+      <h2 class="grow font-semibold truncate">
+        <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
+      </h2>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -4,30 +4,9 @@
 
 <main class="grow" data-controller="visualization--issue-filtering">
   <div class="flex flex-col h-full">
-    <div class="flex flex-col sm:px-12 pt-4">
-      <div class="flex  items-end justify-between gap-2">
-        <h2 class="text-readable-content-800 font-semibold text-3xl text-readable-content-800 py-2">
-          <%= @visualization.project.name %>
-        </h2>
-
-        <div class="flex items-stretch flex-col sm:flex-row gap-4">
-          <%= link_to time_entries_path(new_entry: { project_id: @visualization.project.id }), class: "flex items-center link-secondary flex", data: { turbo_frame: "_top" } do %>
-            <span class="text-sm mr-2"><%= icon_for(:time_entries) %></span>
-            <span class="text-sm sm:block"><%= t("actions.go_to_time_tracking") %></span>
-          <% end %>
-        </div>
-        </div>
-      <div class="mt-2 flex gap-4 text-sm font-medium border-b border-readable-content-300">
-        <%= link_to project_issues_path(@visualization.project), class: "px-2 pb-1 whitespace-nowrap" do %>
-          <%= t(:all_issues, scope: :nav) %>
-        <% end %>
-
-        <%= link_to '#', class: "px-2 pb-1 border-b-2 border-primary-500 text-primary-500 whitespace-nowrap" do %>
-          <%= t(:board_view, scope: :nav) %>
-        <% end %>
-      </div>
-    </div>
-
+    <%= render partial: 'projects/navigation_header', locals: {
+      project: @visualization.project
+    } %>
 
     <%= turbo_frame_tag('grouping_form') {} %>
 

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -2,7 +2,7 @@
 
 <%= turbo_stream_from @visualization %>
 
-<div class="flex mt-8  flex-col sm:px-8">
+<div class="flex mt-8 flex-col sm:px-8">
   <%= render partial: 'projects/navigation_header', locals: {
     project: @visualization.project
   } %>
@@ -31,7 +31,7 @@
         </div>
       </div>
 
-      <div class="flex items-stretch flex-col sm:flex-row gap-4 my-4">
+      <div class="flex items-stretch flex-col sm:flex-row gap-4">
         <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
           <i class="fa-solid fa-plus mr-2"></i>
 
@@ -52,7 +52,7 @@
     <% end %>
 
 
-    <div class="relative grow cpy-columns-wrapper">
+    <div class="mt-4 relative grow cpy-columns-wrapper">
       <div class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:pl-8 sm:pr-8 sm:pb-4 sm:scroll-pr-8 pb-2 sm:px-8 gap-x-8 flex flex-row overflow-x-auto overflow-y-hidden scroll-smooth">
         <ul
             class="hidden has-[li]:flex flex-row flex-nowrap gap-x-8 items-start"

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -2,12 +2,14 @@
 
 <%= turbo_stream_from @visualization %>
 
+<div class="flex mt-8  flex-col sm:px-8">
+  <%= render partial: 'projects/navigation_header', locals: {
+    project: @visualization.project
+  } %>
+</div>
+
 <main class="grow" data-controller="visualization--issue-filtering">
   <div class="flex flex-col h-full">
-    <%= render partial: 'projects/navigation_header', locals: {
-      project: @visualization.project
-    } %>
-
     <%= turbo_frame_tag('grouping_form') {} %>
 
     <% if @open_issue.present? %>
@@ -15,7 +17,7 @@
     <% else %>
       <%= turbo_frame_tag('issue_form') {} %>
     <% end %>
-    <div class="px-4 sm:px-12 flex justify-between items-center">
+    <div class="px-4 sm:px-8 flex justify-between items-center">
       <div class="flex items-stretch gap-4">
         <div class="input-with-icon-wrapper w-64">
           <div class="icon-wrapper">
@@ -51,7 +53,7 @@
 
 
     <div class="relative grow cpy-columns-wrapper">
-      <div class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:pl-12 sm:pr-12 sm:pb-4 sm:scroll-pr-12 pb-2 sm:px-12 gap-x-8 flex flex-row overflow-x-auto overflow-y-hidden scroll-smooth">
+      <div class="absolute top-0 left-0 right-0 bottom-0 sm:top-0 sm:pl-8 sm:pr-8 sm:pb-4 sm:scroll-pr-8 pb-2 sm:px-8 gap-x-8 flex flex-row overflow-x-auto overflow-y-hidden scroll-smooth">
         <ul
             class="hidden has-[li]:flex flex-row flex-nowrap gap-x-8 items-start"
             id="js-kanban-board"

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -17,31 +17,8 @@
     <% else %>
       <%= turbo_frame_tag('issue_form') {} %>
     <% end %>
-    <div class="px-4 sm:px-8 flex justify-between items-center">
-      <div class="flex items-stretch gap-4">
-        <div class="input-with-icon-wrapper w-64">
-          <div class="icon-wrapper">
-            <i class="text-readable-content-300 fa fa-search"></i>
-          </div>
-          <input class="input-contrast input-sm active cpy-issues-search"
-            placeholder="Search issue"
-            data-visualization--issue-filtering-target="searchInput"
-            data-action="input->visualization--issue-filtering#filterIssues"
-            type="search" placeholder="Search…">
-        </div>
-      </div>
 
-      <div class="flex items-stretch flex-col sm:flex-row gap-4">
-        <%= link_to new_visualization_grouping_path(@visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
-          <i class="fa-solid fa-plus mr-2"></i>
-
-          <h2 class="grow font-semibold truncate">
-            <%= "#{t('actions.create')} #{Grouping.model_name.human.downcase}" %>
-          </h2>
-
-        <% end %>
-      </div>
-    </div>
+    <%= render partial: 'board_header', locals: { visualization: @visualization } %>
 
     <%= turbo_frame_tag('grouping_form') {} %>
 

--- a/config/initializers/ransack.rb
+++ b/config/initializers/ransack.rb
@@ -2,7 +2,11 @@ Ransack.configure do |config|
   # Change default search parameter key name.
   # Default key name is :q
   # config.search_key = :q
-
+  config.custom_arrows = {
+    up_arrow: '<i class="fa-solid fa-sort-up"></i>',
+    down_arrow: '<i class="fa-solid fa-sort-down"></i>',
+    default_arrow: '<i class="fa fa-sort"></i>'
+  }
   # Raise errors if a query contains an unknown predicate or attribute.
   # Default is true (do not raise error on unknown conditions).
   # config.ignore_unknown_conditions = true

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -30,7 +30,6 @@ en:
     actions: "Actions"
   nav:
     all_issues: "All issues"
-    board_view: "Board view"
   actions:
     back: "back"
     new: "New"

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -31,7 +31,6 @@ pt-BR:
     actions: "Ações"
   nav:
     all_issues: "Todas as issues"
-    board_view: "Visão de quadro"
   actions:
     back: "Voltar"
     new: "Novo"

--- a/config/locales/ransack.en.yml
+++ b/config/locales/ransack.en.yml
@@ -11,4 +11,5 @@ en:
       lt: less than
     attributes:
       issue:
+        title_cont: With title
         by_label_titles: With labels


### PR DESCRIPTION
This PR: 
- Creates a `project_header` partial to be reused among different views (it automatically selects the current tab). 
- Improves `select2` to accept custom classes to enable using styles different from the default one
- Changes the Board and All Issues to use the `project_header` tab navigation
- Updates the entire "All issues" UI (filter + table) by making everything more compact
- Redesign the "all issues" filter to be more compact and extracts the HTML to be in a partial, change labels and removes blank option from tags filter
- Changes table design to be more compact
- Extracts table styles to a dedicated component css file
- Changes the table to better indicate that sorting is allowed with ransack icons configuration (pending in future PR to align the header with the icon) 
- Adds action buttons placeholders in the issues table to be used in the future
- Extracts buttons and links to a dedicated CSS File

TODO 
- Changes pagination design 
- Show current pagination results information

![image](https://github.com/user-attachments/assets/6b051677-014c-4a58-8e4a-99156e985227)
