### PR TITLE
chore(pagination): UI styles + i18n translations

### DIFF
--- a/app/assets/tailwind/themes/pagy.tailwind.css
+++ b/app/assets/tailwind/themes/pagy.tailwind.css
@@ -1,31 +1,41 @@
-.pagy {
-  @apply flex items-center -space-x-px h-14 text-sm mx-auto;
+.pagy-summary {
+  @apply flex flex-col sm:flex-row items-center gap-4 justify-between;
 
-  a {
-    @apply flex items-center justify-center px-3 h-8 ms-0 leading-tight text-readable-content-500 bg-body-contrast border border-primary-300;
-
-    &.gap {
-      @apply text-readable-content-200 cursor-default;
-    }
+  .pagy.info {
+    @apply text-sm text-readable-content-500;
   }
 
-  a:not(.gap) {
-    @apply flex items-center justify-center px-3 h-8 ms-0 leading-tight text-readable-content-500 bg-body-contrast border border-primary-300;
+  .pagy.nav {
+    @apply flex text-readable-content-500 text-sm;
 
-    &:hover {
-      @apply bg-primary-100 text-readable-content-700;
+    a {
+      @apply flex items-center justify-center leading-tight px-3.5 py-2 bg-body-contrast hover:bg-readable-content-50;
+
+      &.gap {
+        @apply text-readable-content-200 cursor-default;
+      }
     }
-    &:not([href]) { /* disabled links */
-      @apply text-readable-content-300 bg-primary-100 cursor-default;
-    }
-    &.current {
-      @apply text-primary-500 bg-primary-400;
-    }
-    &:first-child {
-      @apply rounded-s-lg;
-    }
-    &:last-child {
-      @apply rounded-e-lg;
+
+    a:not(.gap) {
+      @apply bg-body-contrast border-r-0 border border-readable-content-300;
+
+      &:hover {
+        @apply bg-primary-100 text-readable-content-700;
+      }
+      &:not([href]) { /* disabled links */
+        @apply text-readable-content-300 bg-readable-content-50 opacity-70 cursor-default;
+      }
+
+      &.current {
+        @apply text-primary-500 font-bold bg-readable-content-100;
+      }
+
+      &:first-child {
+        @apply rounded-s-lg;
+      }
+      &:last-child {
+        @apply rounded-e-lg border-r;
+      }
     }
   }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,7 @@ class ApplicationController < ActionController::Base
     locale = current_user&.locale
     locale = I18n.default_locale if locale.blank?
     response.set_header "Content-Language", locale
+    @pagy_locale = locale
     I18n.with_locale locale, &action
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   include Pagy::Frontend
+  include ApplicationHelper::CustomPagy
 
   include ApplicationHelper::Alerts
   include ApplicationHelper::Forms

--- a/app/helpers/application_helper/custom_pagy.rb
+++ b/app/helpers/application_helper/custom_pagy.rb
@@ -1,0 +1,9 @@
+module ApplicationHelper
+  module CustomPagy
+    def pagy_summary(pagy)
+      content_tag(:div, class: "pagy-summary") do
+        pagy_info(@pagy).html_safe + pagy_nav(@pagy).html_safe
+      end
+    end
+  end
+end

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -26,10 +26,7 @@
         </tbody>
       </table>
 
-      <div class="pagy-summary">
-        <%== pagy_info(@pagy) %>
-        <%== pagy_nav(@pagy) %>
-      </div>
+      <%== pagy_summary(@pagy) %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -26,7 +26,10 @@
         </tbody>
       </table>
 
-      <%== pagy_nav(@pagy) %>
+      <div class="pagy-summary">
+        <%== pagy_info(@pagy) %>
+        <%== pagy_nav(@pagy) %>
+      </div>
     <% end %>
   </div>
 <% end %>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -4,13 +4,12 @@
 # Customize only what you really need and notice that the core Pagy works also without any of the following lines.
 # Should you just cherry pick part of this file, please maintain the require-order of the extras
 
-
 # Pagy Variables
 # See https://ddnexus.github.io/pagy/docs/api/pagy#variables
 # You can set any pagy variable as a Pagy::DEFAULT. They can also be overridden per instance by just passing them to
 # Pagy.new|Pagy::Countless.new|Pagy::Calendar::*.new or any of the #pagy* controller methods
 # Here are the few that make more sense as DEFAULTs:
-Pagy::DEFAULT[:limit]       = 10                    # default
+Pagy::DEFAULT[:limit]       = 50                    # default
 # Pagy::DEFAULT[:size]        = 5                     # default
 # Pagy::DEFAULT[:ends]        = true                  # default
 # Pagy::DEFAULT[:page_param]  = :page                 # default
@@ -189,16 +188,15 @@ Pagy::DEFAULT[:limit_max]   = 100      # default
 #
 # Examples:
 # load the "de" built-in locale:
-# Pagy::I18n.load(locale: 'de')
+# Pagy::I18n.load(locale: 'pt-BR')
 #
 # load the "de" locale defined in the custom file at :filepath:
 # Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
 #
 # load the "de", "en" and "es" built-in locales:
 # (the first passed :locale will be used also as the default_locale)
-# Pagy::I18n.load({ locale: 'de' },
-#                 { locale: 'en' },
-#                 { locale: 'es' })
+Pagy::I18n.load({ locale: "en" },
+                { locale: "pt-BR" })
 #
 # load the "en" built-in locale, a custom "es" locale,
 # and a totally custom locale complete with a custom :pluralize proc:


### PR DESCRIPTION
This PR: 

- Changes Pagy css styles 
- Setup Pagy I18n translations.
- Creates a `pagy_summary(pagy)` helper method to render the our entire pagination information
- Changes pagination limit to 50

![image](https://github.com/user-attachments/assets/d1bdddd1-6168-40f5-b0ef-33884e22147e)

