### PR TITLE
feat(Board/FavoriteLabels): keyboard shortcuts to apply/remove labels

### DIFF
--- a/app/assets/tailwind/themes/_components/button.css
+++ b/app/assets/tailwind/themes/_components/button.css
@@ -13,7 +13,7 @@
 }
 
 .btn-contrast {
-  @apply border border-readable-content-500 bg-body-contrast text-sm text-readable-content-500 hover:text-readable-content-700 hover:bg-readable-content-100/50 px-4 py-2 rounded-md;
+  @apply border border-readable-content-300 bg-body-contrast text-sm text-readable-content-400 hover:text-readable-content-500 hover:bg-readable-content-100/50 px-4 py-2 rounded-md;
 }
 
 .btn[disabled] .loading-spinner,

--- a/app/assets/tailwind/themes/_components/button.css
+++ b/app/assets/tailwind/themes/_components/button.css
@@ -12,6 +12,10 @@
   @apply border border-primary-500 text-sm text-primary-500 hover:text-primary-700 hover:bg-primary-100/50 px-4 py-2 rounded-md;
 }
 
+.btn-contrast {
+  @apply border border-readable-content-500 bg-body-contrast text-sm text-readable-content-500 hover:text-readable-content-700 hover:bg-readable-content-100/50 px-4 py-2 rounded-md;
+}
+
 .btn[disabled] .loading-spinner,
 .btn-primary[disabled] .loading-spinner,
 .btn-secondary[disabled] .loading-spinner,
@@ -27,8 +31,8 @@
   @apply py-1 px-2 text-xs h-7;
 }
 
-.btn.btn-md {
-  @apply py-1 px-2 text-sm h-9;
+.btn-md {
+  @apply py-1 px-2 text-sm;
 }
 
 .btn-primary.btn-xl,

--- a/app/assets/tailwind/themes/_components/button.css
+++ b/app/assets/tailwind/themes/_components/button.css
@@ -13,7 +13,7 @@
 }
 
 .btn-contrast {
-  @apply border border-readable-content-300 bg-body-contrast text-sm text-readable-content-400 hover:text-readable-content-500 hover:bg-readable-content-100/50 px-4 py-2 rounded-md;
+  @apply border border-readable-content-300 bg-body-contrast text-sm text-readable-content-400 hover:text-primary-500 hover:bg-primary-100/50 px-4 py-2 rounded-md;
 }
 
 .btn[disabled] .loading-spinner,

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -8,10 +8,8 @@ class Projects::IssuesController < ApplicationController
 
   def add_label
     issue = Issue.find(params[:id])
-    label = IssueLabel.find_or_create_by({
-      title: params[:label][:title],
-      project_id: issue.project_id
-    })
+    label = current_project.issue_labels.with_title(params[:label][:title]).first
+    label ||= current_project.issue_labels.create(title: params[:label][:title])
 
     if issue.labels.exclude?(label)
       issue.labels << label
@@ -22,7 +20,7 @@ class Projects::IssuesController < ApplicationController
 
   def remove_label
     issue = Issue.find(params[:id])
-    label = issue.labels.find_by(title: params[:label][:title])
+    label = issue.labels.with_title(params[:label][:title]).first
 
     # "Prevents" (at least for % 99,42 of the cases)
     # Simultaneous requests/crazy multiple clicks

--- a/app/controllers/visualizations_controller.rb
+++ b/app/controllers/visualizations_controller.rb
@@ -1,9 +1,19 @@
 class VisualizationsController < ApplicationController
+  def update
+    @visualization = Visualization.find(params[:id])
+
+    @updated = @visualization.update(visualization_params)
+  end
+
   def show
     @visualization = Visualization.includes(groupings: :issues).find(params[:id])
     if params[:issue_id]
       @open_issue = Issue.find(params[:issue_id])
     end
     skip_layout_content_wrapper!
+  end
+
+  def visualization_params
+    params.require(:visualization).permit(favorite_issue_labels: [])
   end
 end

--- a/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
+++ b/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
@@ -6,6 +6,7 @@ const ISSUE_DATA_ATTRIBUTE = 'data-favorite-issue-labels-issue-id'
 export default class extends Controller {
   static values = {
     addPath: String,
+    removePath: String
   }
 
   static targets = ['favoriteLabelInput']
@@ -18,24 +19,48 @@ export default class extends Controller {
 
       if (hoveredCard) {
         e.preventDefault()
-        const issueId = hoveredCard.getAttribute(ISSUE_DATA_ATTRIBUTE)
         const label = this.favoriteLabelInputTargets[parseInt(key) - 1].value
 
-        this.#applyLabel(issueId, label)
+        this.#toogleLabel(hoveredCard, label)
       }
     }
   }
 
-  #applyLabel(issueId, label) {
+  #toogleLabel(hoveredCard, label) {
     if (label.trim() === "") {
       return;
     }
 
-    console.log(`Label ${label} applied ${issueId}`)
-    console.log(this.addPathValue)
+    const issueId = hoveredCard.getAttribute(ISSUE_DATA_ATTRIBUTE)
+
+    const isLabelAlreadyApplyed = Array.from(hoveredCard.querySelectorAll("[data-issue-label]")).find(el =>
+      el.textContent.toLowerCase().includes(label.toLowerCase())
+    );
+
+    if (isLabelAlreadyApplyed) {
+      this.#removeLabel(issueId, label)
+    } else {
+      this.#applyLabel(issueId, label)
+    }
+
+  }
+
+  #applyLabel(issueId, label) {
     const REQUEST_PATH = this.addPathValue.replace("ISSUE_ID_PLACEHOLDER", issueId)
 
     const request = new FetchRequest('post', REQUEST_PATH, {
+      body: JSON.stringify({
+        label: { title: label }
+      })
+    })
+
+    return request.perform()
+  }
+
+  #removeLabel(issueId, label) {
+    const REQUEST_PATH = this.removePathValue.replace("ISSUE_ID_PLACEHOLDER", issueId)
+
+    const request = new FetchRequest('delete', REQUEST_PATH, {
       body: JSON.stringify({
         label: { title: label }
       })

--- a/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
+++ b/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
@@ -1,5 +1,5 @@
-import { Controller } from "@hotwired/stimulus"
-import consumer from "channels/consumer"
+import { Controller } from '@hotwired/stimulus'
+import { FetchRequest } from '@rails/request.js'
 
 const ISSUE_DATA_ATTRIBUTE = 'data-favorite-issue-labels-issue-id'
 
@@ -7,6 +7,8 @@ export default class extends Controller {
   static values = {
     addPath: String,
   }
+
+  static targets = ['favoriteLabelInput']
 
   onKeyPress(e) {
     const key = e.key
@@ -17,10 +19,29 @@ export default class extends Controller {
       if (hoveredCard) {
         e.preventDefault()
         const issueId = hoveredCard.getAttribute(ISSUE_DATA_ATTRIBUTE)
-        console.log(`Label ${key} applied ${issueId}`)
-        console.log(this.addPathValue)
+        const label = this.favoriteLabelInputTargets[parseInt(key) - 1].value
+
+        this.#applyLabel(issueId, label)
       }
     }
+  }
+
+  #applyLabel(issueId, label) {
+    if (label.trim() === "") {
+      return;
+    }
+
+    console.log(`Label ${label} applied ${issueId}`)
+    console.log(this.addPathValue)
+    const REQUEST_PATH = this.addPathValue.replace("ISSUE_ID_PLACEHOLDER", issueId)
+
+    const request = new FetchRequest('post', REQUEST_PATH, {
+      body: JSON.stringify({
+        label: { title: label }
+      })
+    })
+
+    return request.perform()
   }
 
 }

--- a/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
+++ b/app/javascript/controllers/visualization/favorite_issue_labels_controller.js
@@ -1,0 +1,26 @@
+import { Controller } from "@hotwired/stimulus"
+import consumer from "channels/consumer"
+
+const ISSUE_DATA_ATTRIBUTE = 'data-favorite-issue-labels-issue-id'
+
+export default class extends Controller {
+  static values = {
+    addPath: String,
+  }
+
+  onKeyPress(e) {
+    const key = e.key
+
+    if (key >= "1" && key <= "6") {
+      const hoveredCard = document.querySelector(`[${ISSUE_DATA_ATTRIBUTE}]:hover`)
+
+      if (hoveredCard) {
+        e.preventDefault()
+        const issueId = hoveredCard.getAttribute(ISSUE_DATA_ATTRIBUTE)
+        console.log(`Label ${key} applied ${issueId}`)
+        console.log(this.addPathValue)
+      }
+    }
+  }
+
+}

--- a/app/models/visualization.rb
+++ b/app/models/visualization.rb
@@ -3,8 +3,10 @@ class Visualization < ApplicationRecord
 
   VALID_TYPES = [ "board" ]
 
+  # Associations
   belongs_to :project
   has_many :groupings, -> { order(position: :asc) }
 
+  # Validations
   validates :type, inclusion: { in: VALID_TYPES }
 end

--- a/app/views/visualizations/_board_header.html.erb
+++ b/app/views/visualizations/_board_header.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="flex items-stretch flex-col sm:flex-row gap-4">
-    <%= render partial: 'keyboard_shortcuts', favorite_labels: visualization.favorite_labels %>
+    <%= render partial: 'favorite_labels_dropdown', locals: { visualization: visualization } %>
 
     <%= link_to new_visualization_grouping_path(visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
       <i class="fa-solid fa-plus mr-2"></i>

--- a/app/views/visualizations/_board_header.html.erb
+++ b/app/views/visualizations/_board_header.html.erb
@@ -13,9 +13,7 @@
   </div>
 
   <div class="flex items-stretch flex-col sm:flex-row gap-4">
-    <button class="btn-contrast btn-md">
-      <i class="fa-regular fa-keyboard"></i>
-    </button>
+    <%= render partial: 'keyboard_shortcuts', favorite_labels: visualization.favorite_labels %>
 
     <%= link_to new_visualization_grouping_path(visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
       <i class="fa-solid fa-plus mr-2"></i>

--- a/app/views/visualizations/_board_header.html.erb
+++ b/app/views/visualizations/_board_header.html.erb
@@ -13,6 +13,10 @@
   </div>
 
   <div class="flex items-stretch flex-col sm:flex-row gap-4">
+    <button class="btn-contrast btn-md">
+      <i class="fa-regular fa-keyboard"></i>
+    </button>
+
     <%= link_to new_visualization_grouping_path(visualization), class: "flex text-sm btn-md btn-primary", data: { turbo_frame: 'grouping_form' } do %>
       <i class="fa-solid fa-plus mr-2"></i>
 

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -1,6 +1,7 @@
 <li class="cpy-card"
   id="<%= dom_id(issue) %>"
   data-controller="visualization--board--card"
+  data-favorite-issue-labels-issue-id="<%= issue.id %>"
   data-visualization--board--card-scroll-on-connect-value="<%= local_assigns[:scroll_on_connect] == true %>"
   data-grouping-column-target="card"
   data-grouping-column-issue-id-value="<%= issue.id %>"

--- a/app/views/visualizations/_favorite_labels_dropdown.html.erb
+++ b/app/views/visualizations/_favorite_labels_dropdown.html.erb
@@ -4,10 +4,10 @@
     data-dropdown-target="button">
     <i class="fa-regular fa-keyboard"></i>
   </button>
-  <div data-dropdown-target="menu" class=" origin-top-left pt-4 z-10 absolute top-full border border-background-300 right-0 min-w-56 bg-background-50 rounded-md shadow-lg overflow-hidden mt-2">
+  <div data-dropdown-target="menu" class=" origin-top-left pt-4 z-10 absolute top-full border border-background-300 right-0 min-w-64 bg-background-50 rounded-md shadow-lg overflow-hidden mt-2">
     <div class="px-4 text-xs font-semibold text-readable-content-500 uppercase">
       <span class="mr-1"><%= icon_for(:issue_labels) %></span>
-      Favorite Labels
+      <%= Visualization.human_attribute_name(:favorite_issue_labels) %>
     </div>
     <%= form_with(model: visualization, html: { class: 'mt-4 flex flex-col gap-2' } ) do |f| %>
 
@@ -19,10 +19,15 @@
             class="input-primary h-8 text-xs input-sm">
         </div>
       <% end %>
+      <p class="px-4 mt-2 font-base">
+        <span class="text-primary-500 font-bold text-xs"><i class="fa-solid fa-wand-magic-sparkles"></i> <%= t(".pro_tip.title") %></span>
+        <br/>
+        <span class="text-readable-content-500 text-xs text-italic"><%= t(".pro_tip.description") %></span>
+      </p>
       <div class="px-4 py-2 border-t border-readable-content-200 flex items-center text-xs bg-readable-content-100 justify-between">
-          <a class="link-base cursor-pointer" data-action="click->dropdown#toggle">Close</a>
+          <a class="link-base cursor-pointer" data-action="click->dropdown#toggle"><%= t(:close, scope: :actions) %></a>
 
-          <button class="btn-sm btn-primary" data-action="click->dropdown#toggle">Save</button>
+          <button class="btn-sm btn-primary" data-action="click->dropdown#toggle"><%= t(:save, scope: :actions) %></button>
 
       </div>
     <% end %>

--- a/app/views/visualizations/_favorite_labels_dropdown.html.erb
+++ b/app/views/visualizations/_favorite_labels_dropdown.html.erb
@@ -1,24 +1,31 @@
 
-<div class="relative inline-flex">
-  <button class="btn-contrast btn-md">
+<div class="relative inline-flex cpy-keyboard-shortcuts" data-controller="dropdown">
+  <button class="btn-contrast btn-md" data-action="click->dropdown#toggle click@window->dropdown#hide"
+    data-dropdown-target="button">
     <i class="fa-regular fa-keyboard"></i>
   </button>
-  <div class="origin-top-left px-4 py-4 z-10 absolute top-full border border-background-300 right-0 min-w-56 bg-background-50 rounded-md shadow-lg overflow-hidden mt-2">
-    <div class="text-xs font-semibold text-readable-content-500 uppercase">
-      <span><i class="fa fa-tags mr-1"></i></span>
+  <div data-dropdown-target="menu" class=" origin-top-left pt-4 z-10 absolute top-full border border-background-300 right-0 min-w-56 bg-background-50 rounded-md shadow-lg overflow-hidden mt-2">
+    <div class="px-4 text-xs font-semibold text-readable-content-500 uppercase">
+      <span class="mr-1"><%= icon_for(:issue_labels) %></span>
       Favorite Labels
     </div>
-    <div class="mt-4 flex flex-col gap-2">
+    <%= form_with(model: visualization, html: { class: 'mt-4 flex flex-col gap-2' } ) do |f| %>
+
       <% 6.times do |i| %>
-        <div class="flex gap-2 items-stretch">
-          <span class="flex items-center bg-background-50 w-4 text-center text-readable-content-500 text-xs font-bold"><%= i %></span>
-          <input type="text" class="input-primary h-8 text-xs input-sm" value="<%= visualization.favorite_issue_labels[i] %>">
-          <button class="btn-contrast btn-md">
-            <i class="fa fa-check"></i>
-          </button>
+        <div class="px-4 flex gap-2 items-stretch">
+          <span class="flex items-center bg-background-50 w-4 text-center text-readable-content-500 text-xs font-bold"><%= i + 1 %></span>
+          <input type="text" name="visualization[favorite_issue_labels][]"
+            value="<%= visualization.favorite_issue_labels[i] %>"
+            class="input-primary h-8 text-xs input-sm">
         </div>
       <% end %>
-    </div>
+      <div class="px-4 py-2 border-t border-readable-content-200 flex items-center text-xs bg-readable-content-100 justify-between">
+          <a class="link-base cursor-pointer" data-action="click->dropdown#toggle">Close</a>
+
+          <button class="btn-sm btn-primary" data-action="click->dropdown#toggle">Save</button>
+
+      </div>
+    <% end %>
 
   </div>
 </div>

--- a/app/views/visualizations/_favorite_labels_dropdown.html.erb
+++ b/app/views/visualizations/_favorite_labels_dropdown.html.erb
@@ -15,6 +15,7 @@
         <div class="px-4 flex gap-2 items-stretch">
           <span class="flex items-center bg-background-50 w-4 text-center text-readable-content-500 text-xs font-bold"><%= i + 1 %></span>
           <input type="text" name="visualization[favorite_issue_labels][]"
+            data-visualization--favorite-issue-labels-target="favoriteLabelInput"
             value="<%= visualization.favorite_issue_labels[i] %>"
             class="input-primary h-8 text-xs input-sm">
         </div>

--- a/app/views/visualizations/_favorite_labels_dropdown.html.erb
+++ b/app/views/visualizations/_favorite_labels_dropdown.html.erb
@@ -1,0 +1,24 @@
+
+<div class="relative inline-flex">
+  <button class="btn-contrast btn-md">
+    <i class="fa-regular fa-keyboard"></i>
+  </button>
+  <div class="origin-top-left px-4 py-4 z-10 absolute top-full border border-background-300 right-0 min-w-56 bg-background-50 rounded-md shadow-lg overflow-hidden mt-2">
+    <div class="text-xs font-semibold text-readable-content-500 uppercase">
+      <span><i class="fa fa-tags mr-1"></i></span>
+      Favorite Labels
+    </div>
+    <div class="mt-4 flex flex-col gap-2">
+      <% 6.times do |i| %>
+        <div class="flex gap-2 items-stretch">
+          <span class="flex items-center bg-background-50 w-4 text-center text-readable-content-500 text-xs font-bold"><%= i %></span>
+          <input type="text" class="input-primary h-8 text-xs input-sm" value="<%= visualization.favorite_issue_labels[i] %>">
+          <button class="btn-contrast btn-md">
+            <i class="fa fa-check"></i>
+          </button>
+        </div>
+      <% end %>
+    </div>
+
+  </div>
+</div>

--- a/app/views/visualizations/_favorite_labels_dropdown.html.erb
+++ b/app/views/visualizations/_favorite_labels_dropdown.html.erb
@@ -9,12 +9,16 @@
       <span class="mr-1"><%= icon_for(:issue_labels) %></span>
       <%= Visualization.human_attribute_name(:favorite_issue_labels) %>
     </div>
-    <%= form_with(model: visualization, html: { class: 'mt-4 flex flex-col gap-2' } ) do |f| %>
+    <%= form_with(model: visualization, html: {
+      class: 'mt-4 flex flex-col gap-2',
+      data: { controller: 'form' }
+      } ) do |f| %>
 
       <% 6.times do |i| %>
         <div class="px-4 flex gap-2 items-stretch">
           <span class="flex items-center bg-background-50 w-4 text-center text-readable-content-500 text-xs font-bold"><%= i + 1 %></span>
           <input type="text" name="visualization[favorite_issue_labels][]"
+            data-action="change->form#submit"
             data-visualization--favorite-issue-labels-target="favoriteLabelInput"
             value="<%= visualization.favorite_issue_labels[i] %>"
             class="input-primary h-8 text-xs input-sm">
@@ -26,10 +30,7 @@
         <span class="text-readable-content-500 text-xs text-italic"><%= t(".pro_tip.description") %></span>
       </p>
       <div class="px-4 py-2 border-t border-readable-content-200 flex items-center text-xs bg-readable-content-100 justify-between">
-          <a class="link-base cursor-pointer" data-action="click->dropdown#toggle"><%= t(:close, scope: :actions) %></a>
-
-          <button class="btn-sm btn-primary" data-action="click->dropdown#toggle"><%= t(:save, scope: :actions) %></button>
-
+        <button class="btn-sm btn-primary" data-action="click->dropdown#toggle"><%= t(:save, scope: :actions) %></button>
       </div>
     <% end %>
 

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -10,7 +10,7 @@
 
 <main class="grow"
   data-controller="visualization--issue-filtering visualization--favorite-issue-labels"
-  data-action="keypress@window->visualization--favorite-issue-labels#onKeyPress"
+  data-action="keydown@window->visualization--favorite-issue-labels#onKeyPress"
   data-visualization--favorite-issue-labels-add-path-value="<%= add_label_project_issue_path(@visualization.project, 'ISSUE_ID_PLACEHOLDER') %>"
   data-visualization--favorite-issue-labels-remove-path-value="<%= remove_label_project_issue_path(@visualization.project, 'ISSUE_ID_PLACEHOLDER') %>"
   >

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -12,6 +12,7 @@
   data-controller="visualization--issue-filtering visualization--favorite-issue-labels"
   data-action="keypress@window->visualization--favorite-issue-labels#onKeyPress"
   data-visualization--favorite-issue-labels-add-path-value="<%= add_label_project_issue_path(@visualization.project, 'ISSUE_ID_PLACEHOLDER') %>"
+  data-visualization--favorite-issue-labels-remove-path-value="<%= remove_label_project_issue_path(@visualization.project, 'ISSUE_ID_PLACEHOLDER') %>"
   >
   <div class="flex flex-col h-full">
     <%= turbo_frame_tag('grouping_form') {} %>

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -8,7 +8,11 @@
   } %>
 </div>
 
-<main class="grow" data-controller="visualization--issue-filtering">
+<main class="grow"
+  data-controller="visualization--issue-filtering visualization--favorite-issue-labels"
+  data-action="keypress@window->visualization--favorite-issue-labels#onKeyPress"
+  data-visualization--favorite-issue-labels-add-path-value="<%= add_label_project_issue_path(@visualization.project, 'ISSUE_ID_PLACEHOLDER') %>"
+  >
   <div class="flex flex-col h-full">
     <%= turbo_frame_tag('grouping_form') {} %>
 

--- a/app/views/visualizations/update.turbo_stream.erb
+++ b/app/views/visualizations/update.turbo_stream.erb
@@ -1,0 +1,5 @@
+<% if @updated %>
+  <%= new_turbo_stream_alert_message(:success, t_flash_message(@visualization)) %>
+<% else %>
+  <%= new_turbo_stream_alert_message(:error, @visualization.errors.full_messages.to_sentence) %>
+<% end %>

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -17,6 +17,10 @@ en:
     issues:
       form:
         destroy_confirmation: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
+    favorite_labels_dropdown:
+      pro_tip:
+        title: "PRO TIP"
+        description: "Hover over a card and press any number from 1 to 6 on your keyboard to apply a label."
   profiles:
     form:
       why_is_timezone_needed: 'This is needed in order to correctly display dates and hours for you.'

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -20,7 +20,7 @@ en:
     favorite_labels_dropdown:
       pro_tip:
         title: "PRO TIP"
-        description: "Hover over a card and press any number from 1 to 6 on your keyboard to apply a label."
+        description: "Hover over a card and press any number from 1 to 6 on your keyboard to apply/remove a label."
   profiles:
     form:
       why_is_timezone_needed: 'This is needed in order to correctly display dates and hours for you.'

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -5,8 +5,8 @@ pt-BR:
       disable_time_tracking: 'Desabilitar registro de tempo'
     issue_labels:
       destroy_confirmation:
-        explanation: "Deletar esse rótulo removerá todas as suas associações com issues, mas não removerá as issues."
-        associations: "Este rótulo está associado com %{count_text)"
+        explanation: "Deletar essa label removerá todas as suas associações com issues, mas não removerá as issues."
+        associations: "Esta label está associado com %{count_text)"
   profiles:
     form:
       why_is_timezone_needed: "Precisamos desta informação para mostrar datas e horários corretamente para você."

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -35,6 +35,10 @@ pt-BR:
     issues:
       form:
         destroy_confirmation: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
+    favorite_labels_dropdown:
+      pro_tip:
+        title: "DICA RÁPIDA"
+        description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar uma label."
   time_entries:
     form:
       save_on_command_enter: Pressione (CTRL + Enter) ou (CMD + Enter) para salvar

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -38,7 +38,7 @@ pt-BR:
     favorite_labels_dropdown:
       pro_tip:
         title: "DICA RÁPIDA"
-        description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar uma label."
+        description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar/remover uma label."
   time_entries:
     form:
       save_on_command_enter: Pressione (CTRL + Enter) ou (CMD + Enter) para salvar

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -63,3 +63,6 @@ en:
         issue: 'Issue'
         project: 'Project'
         total_logged_time_in_minutes: 'Logged time (minutes)'
+
+      visualization:
+        favorite_issue_labels: "Favorite labels"

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -63,3 +63,6 @@ pt-BR:
         issue_id: 'Issue'
         issue: 'Issue'
         total_logged_time_in_minutes: 'Tempo registrado (minutos)'
+
+      visualization:
+        favorite_issue_labels: "Rótulos favoritos"

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -26,8 +26,8 @@ pt-BR:
         other: 'Issues'
 
       issue_label:
-        one: 'Rótulo de Issues'
-        other: 'Rótulos de Issues'
+        one: 'Label de Issues'
+        other: 'Labels de Issues'
 
       time_entry:
         one: 'Registro de tempo'
@@ -48,8 +48,8 @@ pt-BR:
         title: 'Título'
         description: 'Descrição'
         files: "Arquivos"
-        labels: 'Rótulos'
-        label_ids: 'Rótulos'
+        labels: 'Labels'
+        label_ids: 'Labels'
         created_at: 'Criado em'
         updated_at: 'Atualizado em'
 
@@ -65,4 +65,4 @@ pt-BR:
         total_logged_time_in_minutes: 'Tempo registrado (minutos)'
 
       visualization:
-        favorite_issue_labels: "Rótulos favoritos"
+        favorite_issue_labels: "Labels favoritas"

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -32,7 +32,7 @@ pt-BR:
     actions: "Ações"
   nav:
     all_issues: "Todas as issues"
-    manage_issue_labels: "Gerenciar rótulos de issues"
+    manage_issue_labels: "Gerenciar labels de issues"
   actions:
     back: "Voltar"
     new: "Novo"

--- a/config/locales/page_title.pt-BR.yml
+++ b/config/locales/page_title.pt-BR.yml
@@ -6,4 +6,4 @@ pt-BR:
     reports: "Relatórios"
     edit_profile: "Perfil e Newsletter"
     project_all_issues: "%{project_name} - Todas as issues"
-    project_all_issue_labels: "%{project_name} - Todos os rótulos de issues"
+    project_all_issue_labels: "%{project_name} - Todos os labels de issues"

--- a/config/locales/ransack.pt-BR.yml
+++ b/config/locales/ransack.pt-BR.yml
@@ -11,4 +11,4 @@ pt-BR:
       lt: menor que
     attributes:
       issue:
-        by_label_titles: Com rótulos
+        by_label_titles: Com labels

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
       controller: :visualizations,
       action: :show
 
-  resources :visualizations, path: "v", only: :show do
+  resources :visualizations, path: "v", only: [ :show, :update ] do
     scope module: :visualizations do
       resources :groupings, only: [ :new, :create, :edit, :update, :destroy ] do
         collection do

--- a/db/migrate/20250209120105_add_favorite_issue_labels_to_visualizations.rb
+++ b/db/migrate/20250209120105_add_favorite_issue_labels_to_visualizations.rb
@@ -1,0 +1,5 @@
+class AddFavoriteIssueLabelsToVisualizations < ActiveRecord::Migration[8.0]
+  def change
+    add_column :visualizations, :favorite_issue_labels, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -130,7 +130,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_09_120105) do
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.json "favorite_tags", default: [], null: false
+    t.json "favorite_issue_labels", default: [], null: false
     t.index ["project_id"], name: "index_visualizations_on_project_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_03_235312) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_09_120105) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -130,6 +130,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_03_235312) do
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "favorite_tags", default: [], null: false
     t.index ["project_id"], name: "index_visualizations_on_project_id"
   end
 

--- a/spec/features/project_management/kanban/using_favorite_labels_spec.rb
+++ b/spec/features/project_management/kanban/using_favorite_labels_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+describe 'As a project manager, I want to use favorite issue labels' do
+  let!(:user) { FactoryBot.create(:user) }
+
+  let!(:project) { FactoryBot.create(:project) }
+  let(:visualization) { project.default_visualization }
+  let!(:grouping) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO") }
+  let!(:issue) { FactoryBot.create(:issue, title: "Issue testing title", description: "Issue description", project: project) }
+
+  let!(:label_development) { project.issue_labels.create!(title: 'Development') }
+  let!(:label_marketing) { project.issue_labels.create!(title: 'Marketing') }
+  let!(:label_urgent) { project.issue_labels.create!(title: 'Urgent') }
+
+  specify "I can add a favorite tag" do
+    visit visualization_path(project.default_visualization)
+
+    find(".cpy-keyboard-shortcuts button").click
+
+    all(".cpy-keyboard-shortcuts form input")[2].set "Development"
+    all(".cpy-keyboard-shortcuts form input")[3].set "New Tag"
+
+    all(".cpy-keyboard-shortcuts form button")[0].click
+
+    visualization.reload
+    expect(visualization.favorite_issue_labels).to eq([ "", "", 'Development', 'New Tag', "", "" ])
+  end
+
+  specify "It shows existing tags" do
+    visualization.favorite_issue_labels = [ "Development", "Urgent", nil, "Another" ]
+    visualization.save!
+
+    visit visualization_path(project.default_visualization)
+
+    find(".cpy-keyboard-shortcuts button").click
+
+    input_values = all(".cpy-keyboard-shortcuts form input").map { _1.value }
+    expect(input_values[0]).to eq("Development")
+    expect(input_values[1]).to eq("Urgent")
+    expect(input_values[2]).to eq("")
+    expect(input_values[3]).to eq("Another")
+    expect(input_values[4]).to eq("")
+    expect(input_values[5]).to eq("")
+  end
+end

--- a/spec/models/visualization_spec.rb
+++ b/spec/models/visualization_spec.rb
@@ -1,13 +1,4 @@
 require 'rails_helper'
 
 describe Visualization do
-  describe '#favorite_issue_labels' do
-    it "returns at least 6 elements" do
-      visualization = FactoryBot.create :visualization
-      visualization.favorite_issue_labels = []
-      visualization.save!
-
-      expect(visualization.favorite_issue_labels).to eq (Array.new(6))
-    end
-  end
 end

--- a/spec/models/visualization_spec.rb
+++ b/spec/models/visualization_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Visualization do
+  describe '#favorite_issue_labels' do
+    it "returns at least 6 elements" do
+      visualization = FactoryBot.create :visualization
+      visualization.favorite_issue_labels = []
+      visualization.save!
+
+      expect(visualization.favorite_issue_labels).to eq (Array.new(6))
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces great enhancements to the Workflow Board and improves the label/issue management usability:

- Adds a dropdown for favorite issue labels directly on the board.
- Implements keyboard shortcuts (1–6) to apply or remove a favorite label from a card by hovering over it.
- Reverts PT-BR translations to use "Labels" instead of "Rótulos."
- Fixes the label search logic in the Projects::IssuesController to be case-insensitive.

# Implementation Details

- Adds a `favorite_issue_labels` to visualizations, which can be updated via the VisualizationsController#update action
- Creates a reusable favorite_issue_labels_controller.js within the visualizations namespace.
- The stimulus controller is inside the visualizations namespace
- Although the feature could be reused on the the 'All Issues' view, implementing it there would require a 'favorite labels' field at the project level. In addition, this view in the future can have bulk editing (PRO Edition), making it less relevant to apply labels via shortcut (and also avoids future UI logic complications).

![labels-shortcut](https://github.com/user-attachments/assets/34900e6a-cb4e-4e1f-a06d-d103fc9541bd)