### PR TITLE
chore: websockets security

### DIFF
--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,4 +1,17 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
+    before_subscribe :verify_token
+    attribute_reader :signed_params
+
+    def verify_token
+      return unless params[:token].present?
+
+      begin
+        @signed_params = HashWithIndifferentAccess.new(StreamSigner.verify_token(params[:token]))
+        puts signed_params
+      rescue
+        reject_unauthorized_connection
+      end
+    end
   end
 end

--- a/app/channels/application_cable/channel.rb
+++ b/app/channels/application_cable/channel.rb
@@ -1,17 +1,19 @@
 module ApplicationCable
   class Channel < ActionCable::Channel::Base
     before_subscribe :verify_token
-    attribute_reader :signed_params
 
     def verify_token
       return unless params[:token].present?
 
       begin
         @signed_params = HashWithIndifferentAccess.new(StreamSigner.verify_token(params[:token]))
-        puts signed_params
       rescue
         reject_unauthorized_connection
       end
+    end
+
+    def signed_params
+      @signed_params || {}
     end
   end
 end

--- a/app/channels/visualizations/allocations_channel.rb
+++ b/app/channels/visualizations/allocations_channel.rb
@@ -15,6 +15,6 @@ class Visualizations::AllocationsChannel < ApplicationCable::Channel
   end
 
   def subscribed
-    stream_from "visualizations:#{params[:visualization_id]}:allocations##{params[:action]}"
+    stream_from "visualizations:#{signed_params[:visualization_id]}:allocations##{signed_params[:action]}"
   end
 end

--- a/app/channels/visualizations/groupings_channel.rb
+++ b/app/channels/visualizations/groupings_channel.rb
@@ -14,6 +14,6 @@ class Visualizations::GroupingsChannel < ApplicationCable::Channel
   end
 
   def subscribed
-    stream_from "visualizations:#{params[:visualization_id]}:groupings##{params[:action]}"
+    stream_from "visualizations:#{signed_params[:visualization_id]}:groupings##{signed_params[:action]}"
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,5 @@ module ApplicationHelper
   include ApplicationHelper::PageTitle
   include ApplicationHelper::TimeTracking
   include ApplicationHelper::Labels
+  include ApplicationHelper::WebsocketsSecurity
 end

--- a/app/helpers/application_helper/websockets_security.rb
+++ b/app/helpers/application_helper/websockets_security.rb
@@ -1,0 +1,7 @@
+module ApplicationHelper
+module WebsocketsSecurity
+  def signed_stream_token(object_to_sign)
+    StreamSigner.generate_token(object_to_sign)
+  end
+end
+end

--- a/app/javascript/controllers/visualization/board_controller.js
+++ b/app/javascript/controllers/visualization/board_controller.js
@@ -5,6 +5,8 @@ export default class extends Controller {
   static targets = ['column']
   static values = {
     visualizationId: String,
+    signedGroupingsStreamToken: String,
+    signedAllocationsStreamToken: String
   }
 
   connect() {
@@ -16,7 +18,8 @@ export default class extends Controller {
     return consumer.subscriptions.create({
       channel: "Visualizations::GroupingsChannel",
       visualization_id: this.visualizationIdValue,
-      action: 'update'
+      action: 'update',
+      token: this.signedGroupingsStreamTokenValue
     }, {
       received: this.onGroupingUpdate.bind(this)
     })
@@ -26,7 +29,8 @@ export default class extends Controller {
     return consumer.subscriptions.create({
       channel: "Visualizations::AllocationsChannel",
       visualization_id: this.visualizationIdValue,
-      action: 'update'
+      action: 'update',
+      token: this.signedAllocationsStreamTokenValue
     }, {
       received: this.onCardMove.bind(this)
     })

--- a/app/javascript/controllers/visualization/board_controller.js
+++ b/app/javascript/controllers/visualization/board_controller.js
@@ -4,7 +4,6 @@ import consumer from "channels/consumer"
 export default class extends Controller {
   static targets = ['column']
   static values = {
-    visualizationId: String,
     signedGroupingsStreamToken: String,
     signedAllocationsStreamToken: String
   }
@@ -17,8 +16,6 @@ export default class extends Controller {
   #subscribeToGroupings() {
     return consumer.subscriptions.create({
       channel: "Visualizations::GroupingsChannel",
-      visualization_id: this.visualizationIdValue,
-      action: 'update',
       token: this.signedGroupingsStreamTokenValue
     }, {
       received: this.onGroupingUpdate.bind(this)
@@ -28,8 +25,6 @@ export default class extends Controller {
   #subscribeToAllocations() {
     return consumer.subscriptions.create({
       channel: "Visualizations::AllocationsChannel",
-      visualization_id: this.visualizationIdValue,
-      action: 'update',
       token: this.signedAllocationsStreamTokenValue
     }, {
       received: this.onCardMove.bind(this)

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -44,6 +44,9 @@
             data-sortable-ignore-drag-selector-value=".js-no-column-drag"
             data-sortable-move-path-value="<%= move_visualization_groupings_path(@visualization) %>"
             data-visualization--board-visualization-id-value="<%= @visualization.id %>"
+            data-visualization--board-test-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
+            data-visualization--board-signed-groupings-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
+            data-visualization--board-signed-allocations-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             >
           <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping, locals: {
             visualization: @visualization,

--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -43,8 +43,6 @@
             data-sortable-target="container"
             data-sortable-ignore-drag-selector-value=".js-no-column-drag"
             data-sortable-move-path-value="<%= move_visualization_groupings_path(@visualization) %>"
-            data-visualization--board-visualization-id-value="<%= @visualization.id %>"
-            data-visualization--board-test-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             data-visualization--board-signed-groupings-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             data-visualization--board-signed-allocations-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             >

--- a/lib/stream_signer.rb
+++ b/lib/stream_signer.rb
@@ -1,19 +1,21 @@
 module StreamSigner
+  GENERIC_CHANNEL = :generic_channel
+
   class InvalidSignatureError < StandardError
-    def initialize(channel, token)
-      super("Invalid token provided: #{token} for channel #{channel}")
+    def initialize(token)
+      super("Invalid token provided: #{token}")
     end
   end
 
-  def self.generate_token(channel, stream)
-    Rails.application.message_verifier(channel).generate(stream)
+  def self.generate_token(stream)
+    Rails.application.message_verifier(GENERIC_CHANNEL).generate(stream)
   end
 
-  def self.verify_token(channel, token)
+  def self.verify_token(token)
     begin
-      Rails.application.message_verifier(channel).verify(token)
+      Rails.application.message_verifier(GENERIC_CHANNEL).verify(token)
     rescue ActiveSupport::MessageVerifier::InvalidSignature
-      raise InvalidSignatureError.new(channel, token)
+      raise InvalidSignatureError.new(token)
     end
   end
 end

--- a/lib/stream_signer.rb
+++ b/lib/stream_signer.rb
@@ -1,0 +1,19 @@
+module StreamSigner
+  class InvalidSignatureError < StandardError
+    def initialize(channel, token)
+      super("Invalid token provided: #{token} for channel #{channel}")
+    end
+  end
+
+  def self.generate_token(channel, stream)
+    Rails.application.message_verifier(channel).generate(stream)
+  end
+
+  def self.verify_token(channel, token)
+    begin
+      Rails.application.message_verifier(channel).verify(token)
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      raise InvalidSignatureError.new(channel, token)
+    end
+  end
+end

--- a/spec/lib/stream_signer_spec.rb
+++ b/spec/lib/stream_signer_spec.rb
@@ -1,13 +1,22 @@
 require 'rails_helper'
 
 describe StreamSigner do
-  specify 'encryption/decryption proccess' do
+  specify 'encryption/decryption using a string' do
     token = subject.generate_token('users:4')
 
     expect(token.size).to eq(54)
 
     verified_message = subject.verify_token(token)
     expect(verified_message).to eq('users:4')
+  end
+
+
+  specify 'encryption/decryption using a hash' do
+    token = subject.generate_token({ symbol_key: "symbol", "string_key": "string" })
+
+    verified_message = subject.verify_token(token)
+    expect(verified_message["symbol_key"]).to eq("symbol")
+    expect(verified_message["string_key"]).to eq("string")
   end
 
   it 'raises and error if the token signature is invalid' do

--- a/spec/lib/stream_signer_spec.rb
+++ b/spec/lib/stream_signer_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+describe StreamSigner do
+  specify 'encryption/decryption proccess' do
+    token = subject.generate_token(:users_channel, 'users:4')
+
+    expect(token.size).to eq(54)
+
+    verified_message = subject.verify_token(:users_channel, token)
+    expect(verified_message).to eq('users:4')
+  end
+
+  it 'raises and error if the token signature is invalid' do
+    token = subject.generate_token(:users_channel, 'users:4')
+
+    expect {
+      subject.verify_token(:other_chanel, token)
+    }.to raise_error(StreamSigner::InvalidSignatureError, "Invalid token provided: InVzZXJzOjQi--53f575e803caa8e70b76de455cdc4bdda7fe1e68 for channel other_chanel")
+  end
+end

--- a/spec/lib/stream_signer_spec.rb
+++ b/spec/lib/stream_signer_spec.rb
@@ -2,19 +2,19 @@ require 'rails_helper'
 
 describe StreamSigner do
   specify 'encryption/decryption proccess' do
-    token = subject.generate_token(:users_channel, 'users:4')
+    token = subject.generate_token('users:4')
 
     expect(token.size).to eq(54)
 
-    verified_message = subject.verify_token(:users_channel, token)
+    verified_message = subject.verify_token(token)
     expect(verified_message).to eq('users:4')
   end
 
   it 'raises and error if the token signature is invalid' do
-    token = subject.generate_token(:users_channel, 'users:4')
+    token = subject.generate_token('users:4')
 
     expect {
-      subject.verify_token(:other_chanel, token)
-    }.to raise_error(StreamSigner::InvalidSignatureError, "Invalid token provided: InVzZXJzOjQi--53f575e803caa8e70b76de455cdc4bdda7fe1e68 for channel other_chanel")
+      subject.verify_token('InVzZXJzOjQi--53f575e803caa8e70b76de455cdc4bdda7fe1e68')
+    }.to raise_error(StreamSigner::InvalidSignatureError, "Invalid token provided: InVzZXJzOjQi--53f575e803caa8e70b76de455cdc4bdda7fe1e68")
   end
 end


### PR DESCRIPTION
This PR improves websocket security (not too relevant here but it would be useful for the PRO/hosted edition) by providing an interface for connecting using a token instead of raw params. This, together with other verifications that should be done on the other editions, should prevent an undesirable listener to connect to non authorized channels. 

# How
- When manually connection to a stream, we should send a token that contains the params instead of sending the raw parameters
- The token can be generated using a `signed_stream_token` helper method
- The token is validated on the `ApplicationCable::Channel` class in a `before_subscribe` hook 
- It configures a `signed_params` to be used on the child classes