### PR TITLE
feat: time report filter by label

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,6 +12,10 @@ class ReportsController < ApplicationController
         @time_entries = @time_entries.where("reference_date <= ?", params[:report][:end_at].to_date)
       end
 
+      if params[:report][:issue_labels].present?
+        @time_entries = @time_entries.by_issue_labels_title(params[:report][:issue_labels])
+      end
+
       project_ids = (params[:report][:project_ids] || []).reject(&:blank?)
 
       if project_ids.any?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -16,6 +16,10 @@ class Issue < ApplicationRecord
     # This scope is using splat operator because ransack has a buggy behavior
     # for array values with scopes.
     # See more: https://github.com/activerecord-hackery/ransack/issues/404
+
+    # If we call without using ransack it need flatten the array
+    # Issue.by_label_titles("dev", "test")
+    label_titles.flatten!
     from(
       joins(:labels)
         .where("LOWER(issue_labels.title) IN (?)", label_titles.map(&:downcase))

--- a/app/models/time_entry.rb
+++ b/app/models/time_entry.rb
@@ -7,6 +7,9 @@ class TimeEntry < ApplicationRecord
   # Scopes
   scope :by_date, ->(date) { where(reference_date: date) }
   scope :running, -> { where.not(started_at: nil) }
+  scope :by_issue_labels_title, ->(labels) {
+    where(issue_id: Issue.by_label_titles(labels).select(:id))
+  }
 
   # Validations
   validates :reference_date, presence: true

--- a/app/views/reports/_total_time/_filters.html.erb
+++ b/app/views/reports/_total_time/_filters.html.erb
@@ -2,7 +2,7 @@
   <div class="bg-body-contrast rounded-md border border-background-200 p-8 space-y-4">
 
     <div class="flex flex-col w-full justify-stretch items-stretch lg:flex-row gap-8 ">
-      <div class="flex flex-col lg:w-2/4  lg:flex-row justify-stretch items-center gap-4">
+      <div class="flex grow flex-col lg:flex-row justify-stretch items-center gap-4">
         <div class="flex  gap-2 w-full flex-col">
           <%= f.label :project_ids, t(".filter_by_project"), class: "text-readable-content-500 text-sm " %>
           <%
@@ -12,7 +12,22 @@
         </div>
       </div>
 
-      <div class="w-full flex flex-col lg:flex-row lg:w-2/4 justify-stretch items-stretch gap-4 ">
+      <div class="flex grow flex-col lg:flex-row justify-stretch cpy-tags-select items-center gap-4">
+        <div class="flex  gap-2 w-full flex-col">
+          <%= f.label :issue_labels, t(".filter_by_issue_labels"), class: "text-readable-content-500 text-sm " %>
+          <%= f.select :issue_labels,
+            options_for_select(IssueLabel.select(:title).distinct.pluck(:title), params[:report][:issue_labels]),
+            { include_hidden: false },
+            class: 'input-primary',
+            multiple: true,
+            data: {
+              controller: 'select2'
+            }
+                %>
+        </div>
+      </div>
+
+      <div class="w-full flex flex-col lg:flex-row lg:w-2/5 justify-stretch items-stretch gap-4 ">
         <div class="flex grow gap-2 flex-col">
           <%= f.label :start_at, t(".entry_start_at"), class: "text-readable-content-500 text-sm " %>
 

--- a/app/views/reports/_total_time/_report.html.erb
+++ b/app/views/reports/_total_time/_report.html.erb
@@ -18,7 +18,7 @@
 
     <div class="min-w-full mt-8 overflow-x-auto">
       <% if @time_entries.any? %>
-        <table class="table-primary table-compact table-striped">
+        <table class="table-primary table-striped">
           <thead>
             <tr>
               <th style="width: 30px;" class="text-center">#</th>
@@ -29,7 +29,7 @@
               <th></th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="text-xs">
             <%
               total = 0
             %>
@@ -80,4 +80,3 @@
     </div>
   <% end %>
 <% end %>
-

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -72,5 +72,6 @@ en:
       filters:
         generate_report: "Generate report"
         filter_by_project: 'Filter by project'
+        filter_by_issue_labels: 'Filter by issue labels'
         entry_start_at: 'Starting at'
         entry_end_at: 'Ending at'

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -71,5 +71,6 @@ pt-BR:
       filters:
         generate_report: "Gerar relatório"
         filter_by_project: 'Filtrar por projeto'
+        filter_by_issue_labels: 'Filtrar por labels de issues'
         entry_start_at: 'Começando em'
         entry_end_at: 'Terminando em'


### PR DESCRIPTION
This PR implements the ability to generate a time report using issue labels. It shows a multiselect with all the existing labels for the user to choose from. 

![time-reports-filter-by-label](https://github.com/user-attachments/assets/036c2f64-44c7-4fe1-8565-116a3b7ff89b)
