### PR TITLE
chore: workflow changes "Create new issue" from "All Issues" List

### DIFF
--- a/app/javascript/controllers/issue_detail_controller.js
+++ b/app/javascript/controllers/issue_detail_controller.js
@@ -1,49 +1,16 @@
 import { Controller } from "@hotwired/stimulus";
-import { marked } from "marked";
 import { FetchRequest } from '@rails/request.js'
 
 export default class extends Controller {
   static targets = [
     "form",
     "titleField",
-    "descriptionPreview",
-    "descriptionInput",
-    "showEditorButton",
-    "showPreviewButton"
   ]
 
   static values = {
     attachPath: String,
     pathForModalClosed: String,
     submitOnTitleChange: { type: Boolean, default: true }
-  }
-
-  connect() {
-    this._simplemde = new SimpleMDE({
-      element: this.descriptionInputTarget,
-      spellChecker: false,
-      showIcons: [
-        "code",
-        "table"
-
-      ],
-      hideIcons: [
-        "preview",
-        "fullscreen",
-        "side-by-side",
-        "guide"
-      ],
-      previewRender: (plainText, preview) => {
-        window.test = marked.parse(plainText)
-        return marked.parse(plainText);
-      },
-      status: []
-    });
-
-    this._simplemde.codemirror.on("change", () => {
-      this.descriptionInputTarget.value = this._simplemde.value();
-      this.descriptionPreviewTarget.innerHTML = marked.parse(this._simplemde.value());
-    });
   }
 
   onTitleFieldEnter(e) {
@@ -81,18 +48,6 @@ export default class extends Controller {
 
   titleFieldTargetConnected(element) {
     this.lastTitleWas = element.value
-  }
-
-  enablePreview() {
-    this._simplemde.togglePreview();
-    this.showPreviewButtonTarget.classList.add("hidden")
-    this.showEditorButtonTarget.classList.remove("hidden")
-  }
-
-  disablePreview() {
-    this._simplemde.togglePreview();
-    this.showPreviewButtonTarget.classList.remove("hidden")
-    this.showEditorButtonTarget.classList.add("hidden")
   }
 
   fileUploadCompleted(e) {

--- a/app/javascript/controllers/markdown_controller.js
+++ b/app/javascript/controllers/markdown_controller.js
@@ -1,0 +1,51 @@
+import { Controller } from "@hotwired/stimulus";
+import { marked } from "marked";
+
+export default class extends Controller {
+  static targets = [
+    "descriptionPreview",
+    "descriptionInput",
+    "showEditorButton",
+    "showPreviewButton"
+  ]
+
+  connect() {
+    this._simplemde = new SimpleMDE({
+      element: this.descriptionInputTarget,
+      spellChecker: false,
+      showIcons: [
+        "code",
+        "table"
+
+      ],
+      hideIcons: [
+        "preview",
+        "fullscreen",
+        "side-by-side",
+        "guide"
+      ],
+      previewRender: (plainText, preview) => {
+        window.test = marked.parse(plainText)
+        return marked.parse(plainText);
+      },
+      status: []
+    });
+
+    this._simplemde.codemirror.on("change", () => {
+      this.descriptionInputTarget.value = this._simplemde.value();
+      this.descriptionPreviewTarget.innerHTML = marked.parse(this._simplemde.value());
+    });
+  }
+
+  enablePreview() {
+    this._simplemde.togglePreview();
+    this.showPreviewButtonTarget.classList.add("hidden")
+    this.showEditorButtonTarget.classList.remove("hidden")
+  }
+
+  disablePreview() {
+    this._simplemde.togglePreview();
+    this.showPreviewButtonTarget.classList.remove("hidden")
+    this.showEditorButtonTarget.classList.add("hidden")
+  }
+}

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -13,7 +13,7 @@
     </div>
   </div>
   <div class="space-y-4">
-    <%= form_with(model: [current_project, issue], html: { class: 'flex flex-col gap-2', data: { turbo_frame: "_top" } }) do |f| %>
+    <%= form_with(model: issue, url: create_issue_url, html: { class: 'flex flex-col gap-2', data: { turbo_frame: "_top" } }) do |f| %>
       <% if issue.errors.any? %>
         <div class="flex rounded-md w-full border-l-6 border-alert-500 bg-alert-500 bg-opacity-[15%] px-4 py-1 mb-5 shadow-sm md:p-4 text-sm text-alert-500">
           <%= issue.errors.full_messages.to_sentence.capitalize %>

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -1,0 +1,42 @@
+
+<%= turbo_frame_tag 'new_issue_form' do %>
+<%= render_modal do %>
+  <div class="border-b border-background-200 pb-2 mb-4">
+    <div class="flex items-center space-x-2">
+      <div class="flex h-7 w-7 items-center justify-center rounded-lg bg-primary-500/10 p-1 text-primary-500 ">
+        <%= icon_for(:issues) %>
+      </div>
+
+      <h4 class="text-lg font-medium text-readable-content-700">
+        <%= issue.persisted? ? "#{t("actions.edit")} #{Issue.model_name.human}" : "#{t("actions.create")} #{Issue.model_name.human}"%>
+      </h4>
+    </div>
+  </div>
+  <div class="space-y-4">
+    <%= form_with(model: [current_project, issue], html: { class: 'flex flex-col gap-2', data: { turbo_frame: "_top" } }) do |f| %>
+      <% if issue.errors.any? %>
+        <div class="flex rounded-md w-full border-l-6 border-alert-500 bg-alert-500 bg-opacity-[15%] px-4 py-1 mb-5 shadow-sm md:p-4 text-sm text-alert-500">
+          <%= issue.errors.full_messages.to_sentence.capitalize %>
+        </div>
+      <% end %>
+
+      <div class="mb-4 flex flex-col items-stretch gap-2">
+        <%= f.label :title, Issue.human_attribute_name(:title), class: "label-primary" %>
+        <%= f.text_field :title, autofocus: true, class: "input-primary" %>
+      </div>
+
+      <%= render partial: 'issues/description_field', locals: { f:, issue: } %>
+
+      <div class="flex gap-2 justify-center">
+        <a class="btn-cancel" data-action="click->modal#close">
+          <%= t('actions.cancel') %>
+        </a>
+
+        <% text = issue.persisted? ? t('actions.update') : t('actions.create') %>
+        <%= f.button text, class: "btn-primary" %>
+      </div>
+    <% end %>
+  </div>
+
+<% end %>
+<% end %>

--- a/app/views/issues/_description_field.html.erb
+++ b/app/views/issues/_description_field.html.erb
@@ -1,0 +1,24 @@
+
+<div data-controller="markdown" class="mb-4 flex flex-col items-stretch gap-2 markdown">
+  <div class="flex justify-between">
+    <%= f.label :description, Issue.human_attribute_name(:description), class: "label-primary" %>
+    <span class="cursor-pointer text-xs flex items-center" data-markdown-target="showPreviewButton" data-action="click->markdown#enablePreview">
+      <i class="fa fa-eye"></i>
+      <span class="ml-2"><%= t("actions.preview") %></span>
+    </span>
+
+    <span class="cursor-pointer text-xs hidden text-primary-500 flex items-center" data-markdown-target="showEditorButton" data-action="click->markdown#disablePreview">
+      <i class="fa fa-pencil"></i>
+      <span class="ml-2 "><%= t("actions.edit") %></span>
+    </span>
+  </div>
+
+  <div class="markdown-editor">
+    <div class="markdown-content hidden" data-markdown-target="descriptionPreview">
+    </div>
+
+    <%= f.text_area :description, class: "input-primary",
+    "data-markdown-target": 'descriptionInput' %>
+  </div>
+
+</div>

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -68,29 +68,7 @@
               </div>
             <% end %>
 
-            <div class="mb-4 flex flex-col items-stretch gap-2 markdown">
-              <div class="flex justify-between">
-                <%= f.label :description, Issue.human_attribute_name(:description), class: "label-primary" %>
-                <span class="cursor-pointer text-xs flex items-center" data-issue-detail-target="showPreviewButton" data-action="click->issue-detail#enablePreview">
-                  <i class="fa fa-eye"></i>
-                  <span class="ml-2"><%= t("actions.preview") %></span>
-                </span>
-
-                <span class="cursor-pointer text-xs hidden text-primary-500 flex items-center" data-issue-detail-target="showEditorButton" data-action="click->issue-detail#disablePreview">
-                  <i class="fa fa-pencil"></i>
-                  <span class="ml-2 "><%= t("actions.edit") %></span>
-                </span>
-              </div>
-
-              <div class="markdown-editor">
-                <div class="markdown-content hidden" data-issue-detail-target="descriptionPreview">
-                </div>
-
-                <%= f.text_area :description, class: "input-primary",
-                "data-issue-detail-target": 'descriptionInput' %>
-              </div>
-
-            </div>
+            <%= render partial: 'issues/description_field', locals: { f:, issue: } %>
 
             <div class="flex gap-2 justify-end">
               <a class="btn-cancel" data-action="click->modal#close">

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -110,7 +110,7 @@
           <div class="flex flex-col gap-2 text-sm font-medium text-readable-content-700 text-center">
             <h5 class="w-full"><%= t("menu.actions") %></h5>
 
-            <%= link_to destroy_path, class: "btn-danger text-center inline-flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t(".destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
+            <%= link_to destroy_path, class: "btn-danger text-center inline-flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
               <i class="fa-solid fa-trash"></i>
               <%= t("actions.remove") %>
             <% end %>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,4 +1,4 @@
-<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "mt-8 mb-8 cpy-filter-form" do |f| %>
+<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "cpy-filter-form" do |f| %>
   <div class="flex flex-col lg:flex-row justify-between items-stretch gap-4">
     <div class="flex flex-col md:flex-row justify-start items-stretch gap-4">
       <div class="flex gap-2 md:w-60 items-center">
@@ -31,16 +31,5 @@
         <% end %>
       </div>
     </div>
-
-    <div class="flex">
-      <%= link_to new_project_issue_path(current_project), class: "btn-primary grow", data: { turbo_frame: "issue_detail" } do %>
-        <i class="fa-solid fa-plus mr-2"></i>
-
-        <h2 class="grow font-semibold truncate">
-          <%= "#{t('actions.create')} #{Issue.model_name.human.downcase}" %>
-        </h2>
-      <% end %>
-    </div>
-
   </div>
 <% end %>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -14,7 +14,7 @@
         <i class="fa fa-edit"></i>
       <% end %>
 
-      <%= link_to issue_path(issue), class: "link-danger cpy-delete-button", data: { turbo_method: :delete, turbo_confirm: t(".destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
+      <%= link_to issue_path(issue), class: "link-danger cpy-delete-button", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation") } do %>
         <i class="fa fa-trash-can"></i>
       <% end %>
     </div>

--- a/app/views/projects/issues/create.turbo_stream.erb
+++ b/app/views/projects/issues/create.turbo_stream.erb
@@ -1,8 +1,0 @@
-<% if @issue.persisted? %>
-  <% if params[:button] == "save-and-close-modal" %>
-    <%= turbo_stream.update 'issue_detail', "" %>
-  <% end %>
-  <%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>
-<% else %>
-  <%= new_turbo_stream_alert_message(:error, @issue.errors.full_messages.to_sentence) %>
-<% end %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -1,12 +1,19 @@
 <% set_page_title(:project_all_issues, project_name: current_project.name) %>
 
+<%= turbo_frame_tag 'new_issue_form' do %>
+<% end %>
 
 <%= render partial: 'projects/navigation_header', locals: {
   project: current_project
 } %>
 
 <%= turbo_frame_tag 'issues', data: { turbo_action: "advance" } do %>
-  <%= render partial: 'filter', locals: { q: @q } %>
+  <div class="mt-8 mb-8 flex justify-between gap-4 items-center flex-col md:flex-row">
+    <%= render partial: 'filter', locals: { q: @q } %>
+
+    <%= link_to "#{t('actions.create')} #{Issue.model_name.human.downcase}", new_project_issue_path(current_project), class: "btn-primary btn-md", data: { turbo_frame: 'new_issue_form' } %>
+  </div>
+
 
   <div class="flex flex-col gap-3 lg:gap-6 flex-wrap justify-stretch">
     <% if @issues.empty? %>
@@ -15,7 +22,7 @@
           <%= t("zero_records", resource_name: Issue.model_name.human) %>
         </p>
         <p class="mt-3 text-center mb-4">
-          <%= link_to t('click_here_to_create_one'), "link", class: "btn-primary inline-block", data: { turbo_frame: 'issue' } %>
+          <%= link_to t('click_here_to_create_one'), new_project_issue_path(current_project), class: "btn-primary inline-block", data: { turbo_frame: 'new_issue_form' } %>
         </p>
       </div>
     <% else %>
@@ -29,7 +36,7 @@
             <th><%= t(:actions, scope: :menu) %></th>
           </tr>
         </thead>
-        <tbody class="text-sm divide-y">
+        <tbody class="text-sm divide-y" id="all-issues-list">
           <% @issues.each do |issue| %>
             <%= render partial: 'issue', locals: { issue: issue, project: current_project } %>
           <% end %>

--- a/app/views/projects/issues/new.html.erb
+++ b/app/views/projects/issues/new.html.erb
@@ -1,6 +1,1 @@
-<%= render partial: "issues/issue_detail",
-  locals: {
-    issue: @issue,
-    submit_on_title_change: false,
-    form_path: project_issues_path(current_project)
-  } %>
+<%= render partial: "issues/create", locals: { issue: @issue } %>

--- a/app/views/projects/issues/new.html.erb
+++ b/app/views/projects/issues/new.html.erb
@@ -1,1 +1,4 @@
-<%= render partial: "issues/create", locals: { issue: @issue } %>
+<%= render partial: "issues/create", locals: {
+  issue: @issue,
+  create_issue_url: project_issues_path(current_project)
+} %>

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -1,4 +1,6 @@
 en:
+  issue:
+    destroy_confirmation: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
   projects:
     project:
       enable_time_tracking: 'Enable time tracking'
@@ -14,9 +16,6 @@ en:
       edit_column: 'Edit column'
       create_issue: 'Create issue'
       destroy_confirmation: 'Are you sure you want to delete "%{title}" column? It is going to delete all issues on this column!'
-    issues:
-      form:
-        destroy_confirmation: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
     favorite_labels_dropdown:
       pro_tip:
         title: "PRO TIP"

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -1,4 +1,6 @@
 pt-BR:
+  issue:
+    destroy_confirmation: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
   projects:
     project:
       enable_time_tracking: 'Habilitar registro de tempo'
@@ -32,9 +34,6 @@ pt-BR:
       edit_column: 'Editar coluna'
       create_issue: 'Criar issue'
       destroy_confirmation: 'Tem certeza que quer deletar a coluna "%{title}"? Isso vai deletar todos as issues da coluna!'
-    issues:
-      form:
-        destroy_confirmation: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
     favorite_labels_dropdown:
       pro_tip:
         title: "DICA RÁPIDA"

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe 'As a user, I want to manage my project kanban visualization' do
-
   let!(:user) { FactoryBot.create(:user) }
 
   specify 'When I have a recent created project, I can access its default visualization page' do

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -1,22 +1,6 @@
 require 'rails_helper'
 
 describe 'As a user, I want to manage my project kanban visualization' do
-  def write_in_md_editor_field(text)
-    within ".CodeMirror" do
-      # Click makes CodeMirror element active:
-      current_scope.click
-
-      # Find the hidden textarea:
-      field = current_scope.find("textarea", visible: false)
-
-      # Mimic user typing the text:
-      field.send_keys text
-    end
-  end
-
-  def markdown_editor_selector
-    ".CodeMirror-code"
-  end
 
   let!(:user) { FactoryBot.create(:user) }
 

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -83,6 +83,27 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     expect(page).not_to have_content("Third issue")
   end
 
+  specify "I can add a new issue" do
+    project = FactoryBot.create(:project)
+
+    visit project_issues_path(project)
+
+    click_link "Create issue"
+
+    within '#new_issue_form' do
+      fill_in 'issue_title', with: "My issue"
+      write_in_md_editor_field("My description")
+      click_button 'Create'
+    end
+
+    within 'table' do
+      expect(page).to have_content("My issue")
+    end
+
+    expect(Issue.last.title).to eq("My issue")
+    expect(Issue.last.description).to eq("My description")
+  end
+
   specify "I can update issues" do
     project = FactoryBot.create(:project)
 

--- a/spec/support/helpers/markdown_editor.rb
+++ b/spec/support/helpers/markdown_editor.rb
@@ -1,0 +1,23 @@
+module MarkdownEditorHelper
+  def write_in_md_editor_field(text)
+    within ".CodeMirror" do
+      # Click makes CodeMirror element active:
+      current_scope.click
+
+      # Find the hidden textarea:
+      field = current_scope.find("textarea", visible: false)
+
+      # Mimic user typing the text:
+      field.send_keys text
+    end
+  end
+
+  def markdown_editor_selector
+    ".CodeMirror-code"
+  end
+
+end
+
+RSpec.configure do |config|
+  config.include MarkdownEditorHelper, type: :feature
+end

--- a/spec/support/helpers/markdown_editor.rb
+++ b/spec/support/helpers/markdown_editor.rb
@@ -15,7 +15,6 @@ module MarkdownEditorHelper
   def markdown_editor_selector
     ".CodeMirror-code"
   end
-
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This PR changes some behaviors and refactor code for the "Create new issue" workflow from "All issues" list. 

- It's now only using turbo and not turbo streams (it redirects the user to the listing and loses the current sorting. This makes sense as the new default sorting is the `updated_at` attribute)
- Fixed missing translations for issue deletion by moving the key to a top position in the translation file
- Implemented a generic `markdown` stimulus controller
- Extracted the description markdown field to a `issues/_description_field` partial. 
- Changed `/issues/_issue_detail` to use the new `issues/_description_field` partial. 
- Created a `/issues/_create.html.erb` partial to be used on `Projects::IssuesController#new`
- Created specs for issue creation from all issues
- Removed old markdown JS code from `issue_detail_controller.js` 
