### PR TITLE
Feat: Allow column to be choose from issue detail modal/form

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,4 +1,17 @@
 class IssuesController < ApplicationController
+  def pick_grouping
+    issue = Issue.find(params[:id])
+    grouping = issue.project.default_visualization.groupings.find_by(id: params[:grouping_id])
+
+    if grouping.present?
+      @allocation = issue.grouping_issue_allocations.first_or_initialize
+      @allocation.update(grouping: grouping, position: :last)
+    else
+      @allocation = issue.grouping_issue_allocations.first_or_initialize
+      @allocation.delete
+    end
+  end
+
   def destroy
     @issue = Issue.find(params[:id])
     @issue.destroy

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -8,7 +8,7 @@ class IssuesController < ApplicationController
       @allocation.update(grouping: grouping, position: :last)
     else
       @allocation = issue.grouping_issue_allocations.first_or_initialize
-      @allocation.delete
+      @allocation.destroy
     end
   end
 

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -7,7 +7,7 @@ class Projects::IssuesController < ApplicationController
     @q = current_project.issues.ransack(params[:q])
     @q.sorts = "updated_at desc" if @q.sorts.empty?
 
-    @pagy, @issues = pagy(@q.result.includes(:labels))
+    @pagy, @issues = pagy(@q.result.includes(:labels, :groupings))
 
     if params[:id]
       @issue = Issue.find(params[:id])

--- a/app/models/grouping.rb
+++ b/app/models/grouping.rb
@@ -40,6 +40,10 @@ class Grouping < ApplicationRecord
   }
   after_destroy_commit -> { broadcast_remove_to visualization }
 
+  def self.ransackable_attributes(auth_object = nil)
+    [ "title" ]
+  end
+
   def allocate_issue(issue)
     allocations.create(issue: issue, position: :last)
   end

--- a/app/models/grouping_issue_allocation.rb
+++ b/app/models/grouping_issue_allocation.rb
@@ -1,5 +1,5 @@
 class GroupingIssueAllocation < ApplicationRecord
-  belongs_to :issue, dependent: :destroy
+  belongs_to :issue
   belongs_to :grouping
 
   positioned on: :grouping, column: :position

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -4,6 +4,7 @@ class Issue < ApplicationRecord
   has_many_attached :files
   has_many :time_entries, dependent: :nullify
   has_many :grouping_issue_allocations, dependent: :destroy
+  has_many :groupings, through: :grouping_issue_allocations
   ## Relations/Labels
   has_many :label_links, class_name: "IssueLabelLink", dependent: :destroy
   has_many :labels, through: :label_links, source: :issue_label
@@ -34,7 +35,7 @@ class Issue < ApplicationRecord
   end
 
   def self.ransackable_associations(auth_object = nil)
-    [ "labels" ]
+    [ "labels", "grouping_issue_allocations", "groupings" ]
   end
 
   def self.ransackable_scopes(auth_object = nil)

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -36,7 +36,7 @@
             }
             }) do |f| %>
 
-            <div class="mb-4 flex flex-col items-stretch gap-2">
+            <div class="mb-2 flex flex-col items-stretch gap-2">
               <%= f.label :title, Issue.human_attribute_name(:title), class: "label-primary" %>
 
               <div data-controller='resizable-input' class="relative" >
@@ -51,6 +51,9 @@
               </div>
             </div>
 
+            <% if issue.persisted? && issue.project.default_visualization.groupings.present? %>
+              <%= render partial: 'issues/issue_detail/grouping_picker', locals: { issue: issue } %>
+            <% end %>
 
             <% if issue.persisted? %>
               <div data-controller='issue--labels'

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -10,10 +10,10 @@
       >
       <div class="rounded-md shadow-md border-background-300 bg-background-50 border px-2">
         <span>
-          <% if issue.grouping_issue_allocations.empty? %>
+          <% if issue.groupings.empty? %>
             <%= t("no_grouping", scope: "action.issues.pick_grouping") %>
           <% else %>
-            <%= issue.grouping_issue_allocations.first.grouping.title %>
+            <%= issue.groupings.first.title %>
           <% end %>
         </span>
 
@@ -23,7 +23,7 @@
       <div data-dropdown-target="menu" class="flex flex-col bg-body-contrast absolute z-10 top-full left-0 border border-background-300 rounded-lg shadow-lg overflow-hidden whitespace-nowrap mt-1 hidden cpy-grouping-picker-container">
         <% issue.project.default_visualization.groupings.each do |grouping| %>
           <% css_classes = "hover:bg-background-100 py-2 px-4" %>
-          <% is_selected = issue.grouping_issue_allocations.first.try(:grouping) == grouping %>
+          <% is_selected = issue.groupings.first == grouping %>
           <% css_classes += " bg-background-50" if is_selected %>
 
           <%= link_to pick_grouping_issue_path(issue, grouping_id: grouping.try(:id)),
@@ -34,7 +34,7 @@
         <% end %>
 
         <% css_classes = "hover:bg-background-100 py-2 px-4" %>
-        <% is_selected = issue.grouping_issue_allocations.empty? %>
+        <% is_selected = issue.groupings.empty? %>
         <% css_classes += " bg-background-50" if is_selected %>
         <%= link_to pick_grouping_issue_path(issue, grouping_id: nil),
           data: { turbo_method: :patch, turbo_frame: 'issue_pick_grouping' },

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -1,0 +1,47 @@
+<%= turbo_frame_tag 'issue_grouping_picker' do %>
+  <div class="mb-2 flex flex-row items-stretch gap-2" data-controller="dropdown">
+    <span><%= t("in_grouping", scope: "action.issues.pick_grouping") %></span>
+
+    <div
+      class="relative flex"
+      data-action="click->dropdown#toggle click@window->dropdown#hide"
+      role="button" aria-haspopup="true" aria-expanded="false"
+      data-dropdown-target="button"
+      >
+      <div class="rounded-md shadow-md border-background-300 bg-background-50 border px-2">
+        <span>
+          <% if issue.grouping_issue_allocations.empty? %>
+            <%= t("no_grouping", scope: "action.issues.pick_grouping") %>
+          <% else %>
+            <%= issue.grouping_issue_allocations.first.grouping.title %>
+          <% end %>
+        </span>
+
+        <i class="fa-solid fa-angle-down"></i>
+      </div>
+
+      <div data-dropdown-target="menu" class="flex flex-col bg-body-contrast absolute z-10 top-full left-0 border border-background-300 rounded-lg shadow-lg overflow-hidden whitespace-nowrap mt-1 hidden">
+        <% issue.project.default_visualization.groupings.each do |grouping| %>
+          <% css_classes = "hover:bg-background-100 py-2 px-4" %>
+          <% is_selected = issue.grouping_issue_allocations.first.try(:grouping) == grouping %>
+          <% css_classes += " bg-background-50" if is_selected %>
+
+          <%= link_to pick_grouping_issue_path(issue, grouping_id: grouping.try(:id)),
+            data: { turbo_method: :patch, turbo_frame: 'issue_pick_grouping' },
+            class: css_classes do %>
+            <p><%= grouping.title %></p>
+          <% end %>
+        <% end %>
+
+        <% css_classes = "hover:bg-background-100 py-2 px-4" %>
+        <% is_selected = issue.grouping_issue_allocations.empty? %>
+        <% css_classes += " bg-background-50" if is_selected %>
+        <%= link_to pick_grouping_issue_path(issue, grouping_id: nil),
+          data: { turbo_method: :patch, turbo_frame: 'issue_pick_grouping' },
+          class: css_classes do %>
+          <p><%= t("no_grouping", scope: "action.issues.pick_grouping") %></p>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag 'issue_grouping_picker' do %>
   <div class="mb-2 flex flex-row items-stretch gap-2" data-controller="dropdown">
-    <span><%= t("in_grouping", scope: "action.issues.pick_grouping") %></span>
+    <span><%= t("in_grouping", scope: "issues.pick_grouping") %></span>
 
     <div
       class="relative flex cpy-grouping-picker-button"
@@ -11,7 +11,7 @@
       <div class="rounded-md shadow-md border-background-300 bg-background-50 border px-2">
         <span>
           <% if issue.groupings.empty? %>
-            <%= t("no_grouping", scope: "action.issues.pick_grouping") %>
+            <%= t("no_grouping", scope: "issues.pick_grouping") %>
           <% else %>
             <%= issue.groupings.first.title %>
           <% end %>
@@ -39,7 +39,7 @@
         <%= link_to pick_grouping_issue_path(issue, grouping_id: nil),
           data: { turbo_method: :patch, turbo_frame: 'issue_pick_grouping' },
           class: css_classes do %>
-          <p><%= t("no_grouping", scope: "action.issues.pick_grouping") %></p>
+          <p><%= t("no_grouping", scope: "issues.pick_grouping") %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -3,7 +3,7 @@
     <span><%= t("in_grouping", scope: "action.issues.pick_grouping") %></span>
 
     <div
-      class="relative flex"
+      class="relative flex cpy-grouping-picker-button"
       data-action="click->dropdown#toggle click@window->dropdown#hide"
       role="button" aria-haspopup="true" aria-expanded="false"
       data-dropdown-target="button"
@@ -20,7 +20,7 @@
         <i class="fa-solid fa-angle-down"></i>
       </div>
 
-      <div data-dropdown-target="menu" class="flex flex-col bg-body-contrast absolute z-10 top-full left-0 border border-background-300 rounded-lg shadow-lg overflow-hidden whitespace-nowrap mt-1 hidden">
+      <div data-dropdown-target="menu" class="flex flex-col bg-body-contrast absolute z-10 top-full left-0 border border-background-300 rounded-lg shadow-lg overflow-hidden whitespace-nowrap mt-1 hidden cpy-grouping-picker-container">
         <% issue.project.default_visualization.groupings.each do |grouping| %>
           <% css_classes = "hover:bg-background-100 py-2 px-4" %>
           <% is_selected = issue.grouping_issue_allocations.first.try(:grouping) == grouping %>

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag 'issue_grouping_picker' do %>
   <div class="mb-2 flex flex-row items-stretch gap-2" data-controller="dropdown">
-    <span><%= t("in_grouping", scope: "issues.pick_grouping") %></span>
+    <span><%= t(".in_grouping") %></span>
 
     <div
       class="relative flex cpy-grouping-picker-button"
@@ -11,7 +11,7 @@
       <div class="rounded-md shadow-md border-background-300 bg-background-50 border px-2">
         <span>
           <% if issue.groupings.empty? %>
-            <%= t("no_grouping", scope: "issues.pick_grouping") %>
+            <%= t(".no_grouping") %>
           <% else %>
             <%= issue.groupings.first.title %>
           <% end %>
@@ -39,7 +39,7 @@
         <%= link_to pick_grouping_issue_path(issue, grouping_id: nil),
           data: { turbo_method: :patch, turbo_frame: 'issue_pick_grouping' },
           class: css_classes do %>
-          <p><%= t("no_grouping", scope: "issues.pick_grouping") %></p>
+          <p><%= t(".no_grouping") %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/issues/pick_grouping.turbo_stream.erb
+++ b/app/views/issues/pick_grouping.turbo_stream.erb
@@ -1,0 +1,4 @@
+<%= turbo_stream.update 'issue_grouping_picker',
+  partial: 'issues/issue_detail/grouping_picker',
+  locals: { issue: @allocation.issue } %>
+<%= new_turbo_stream_alert_message(:success, t("flash.issues.pick_grouping.success")) %>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -7,7 +7,7 @@
     <% if issue.groupings.present? %>
       <%= issue.groupings.first.title %>
     <% else %>
-      <%= t("no_grouping", scope: "projects.issues.index") %>
+      <%= t(".no_grouping") %>
     <% end %>
   </td>
   <td><%= l issue.created_at, format: :short %></td>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -3,6 +3,13 @@
   <td>
     <%= labels_list_for(issue) %>
   </td>
+  <td>
+    <% if issue.groupings.present? %>
+      <%= issue.groupings.first.title %>
+    <% else %>
+      <%= t("no_grouping", scope: "issues.pick_grouping") %>
+    <% end %>
+  </td>
   <td><%= l issue.created_at, format: :short %></td>
   <td><%= l issue.updated_at, format: :short %></td>
   <td>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -7,7 +7,7 @@
     <% if issue.groupings.present? %>
       <%= issue.groupings.first.title %>
     <% else %>
-      <%= t("no_grouping", scope: "issues.pick_grouping") %>
+      <%= t("no_grouping", scope: "projects.issues.index") %>
     <% end %>
   </td>
   <td><%= l issue.created_at, format: :short %></td>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -31,6 +31,7 @@
           <tr>
             <th><%= sort_link(@q, :title, Issue.human_attribute_name(:title)) %></th>
             <th><%= Issue.human_attribute_name(:labels) %></th>
+            <th><%= sort_link(@q, :groupings_title, Issue.human_attribute_name(:grouping)) %></th>
             <th><%= sort_link(@q, :created_at, Issue.human_attribute_name(:created_at)) %></th>
             <th><%= sort_link(@q, :updated_at, Issue.human_attribute_name(:updated_at)) %></th>
             <th><%= t(:actions, scope: :menu) %></th>

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -10,7 +10,7 @@ en:
         explanation: "Deleting this label will remove all of its associations with issues, but will not remove the issues."
         associations: "This label is associated with %{count_text}"
     issues:
-      index:
+      issue:
         no_grouping: "No column"
   visualizations:
     column_menu:
@@ -45,9 +45,10 @@ en:
     update:
       success: 'Profile succesfully updated.'
   issues:
-    pick_grouping:
-      in_grouping: "In column"
-      no_grouping: "No column"
+    issue_detail:
+      grouping_picker:
+        in_grouping: "In column"
+        no_grouping: "No column"
   time_entries:
     form:
       save_on_command_enter: press (CTRL + Enter) or (CMD + Enter) to save

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -18,7 +18,10 @@ en:
       delete: 'Delete column'
       edit_column: 'Edit column'
       create_issue: 'Create issue'
-      destroy_confirmation: 'Are you sure you want to delete "%{title}" column? It is going to delete all issues on this column!'
+      destroy_confirmation: 'Are you sure you want to delete "%{title}" column? All its issues are going to be moved to "No column"!'
+    issues:
+      form:
+        destroy_confirmation: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
     favorite_labels_dropdown:
       pro_tip:
         title: "PRO TIP"

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -9,6 +9,9 @@ en:
       destroy_confirmation:
         explanation: "Deleting this label will remove all of its associations with issues, but will not remove the issues."
         associations: "This label is associated with %{count_text}"
+    issues:
+      index:
+        no_grouping: "No column"
   visualizations:
     column_menu:
       actions: 'Actions'

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -38,6 +38,10 @@ en:
 
     update:
       success: 'Profile succesfully updated.'
+  issues:
+    pick_grouping:
+      in_grouping: "In column"
+      no_grouping: "No column"
   time_entries:
     form:
       save_on_command_enter: press (CTRL + Enter) or (CMD + Enter) to save

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -10,7 +10,7 @@ pt-BR:
         explanation: "Deletar essa label removerá todas as suas associações com issues, mas não removerá as issues."
         associations: "Esta label está associado com %{count_text)"
     issues:
-      index:
+      issue:
         no_grouping: "Sem coluna"
   profiles:
     form:
@@ -45,9 +45,10 @@ pt-BR:
         title: "DICA RÁPIDA"
         description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar/remover uma label."
   issues:
-    pick_grouping:
-      in_grouping: "Na coluna"
-      no_grouping: "Sem coluna"
+    issue_detail:
+      grouping_picker:
+        in_grouping: "Na coluna"
+        no_grouping: "Sem coluna"
   time_entries:
     form:
       save_on_command_enter: Pressione (CTRL + Enter) ou (CMD + Enter) para salvar

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -36,7 +36,10 @@ pt-BR:
       delete: 'Deletar coluna'
       edit_column: 'Editar coluna'
       create_issue: 'Criar issue'
-      destroy_confirmation: 'Tem certeza que quer deletar a coluna "%{title}"? Isso vai deletar todos as issues da coluna!'
+      destroy_confirmation: 'Tem certeza que quer deletar a coluna "%{title}"? Todas as issues dela serão movidas para "Sem coluna"!'
+    issues:
+      form:
+        destroy_confirmation: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
     favorite_labels_dropdown:
       pro_tip:
         title: "DICA RÁPIDA"

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -38,6 +38,10 @@ pt-BR:
       pro_tip:
         title: "DICA RÁPIDA"
         description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar/remover uma label."
+  issues:
+    pick_grouping:
+      in_grouping: "Na coluna"
+      no_grouping: "Sem coluna"
   time_entries:
     form:
       save_on_command_enter: Pressione (CTRL + Enter) ou (CMD + Enter) para salvar

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -9,6 +9,9 @@ pt-BR:
       destroy_confirmation:
         explanation: "Deletar essa label removerá todas as suas associações com issues, mas não removerá as issues."
         associations: "Esta label está associado com %{count_text)"
+    issues:
+      index:
+        no_grouping: "Sem coluna"
   profiles:
     form:
       why_is_timezone_needed: "Precisamos desta informação para mostrar datas e horários corretamente para você."

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -52,6 +52,7 @@ en:
         label_ids: 'Labels'
         created_at: 'Created at'
         updated_at: 'Updated at'
+        grouping: 'Column'
 
       issue_label:
         title: 'Title'

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -52,6 +52,7 @@ pt-BR:
         label_ids: 'Labels'
         created_at: 'Criado em'
         updated_at: 'Atualizado em'
+        grouping: 'Coluna'
 
       issue_label:
         title: 'Título'

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -66,6 +66,9 @@ en:
     change_success: "Change successfully made."
     change_error: "Change could not be made."
     file_successfully_removed: "File was successfully removed."
+    issues:
+      pick_grouping:
+        success: "Issue column was successfully updated."
     actions:
       create:
         notice: "%{resource_name} was successfully created."

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -67,6 +67,9 @@ pt-BR:
     change_success: "Alteração feita com sucesso."
     change_error: "Houve um erro na hora de realizar a alteração."
     file_successfully_removed: "Arquivo removido com sucesso."
+    issues:
+      pick_grouping:
+        success: "Coluna da issue atualizada com sucesso."
     actions:
       create:
         notice: "%{resource_name} criado(a) com sucesso."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,9 @@ Rails.application.routes.draw do
   end
 
   resources :issues, only: [ :destroy ] do
+    member do
+      patch :pick_grouping
+    end
     scope module: "issues" do
       resource :file, only: [ :destroy ] do
         post :attach, on: :collection

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -60,7 +60,7 @@ describe 'As a user, I want to manage my project kanban visualization' do
     end
   end
 
-  specify 'I can destroy groupings on the Kanban visualization page, with all dependents destroyed too' do
+  specify 'I can destroy groupings on the Kanban visualization page, with all issues going to the "No column" state' do
     project = FactoryBot.create(:project)
     FactoryBot.create(:grouping, visualization: project.default_visualization)
     grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
@@ -89,7 +89,7 @@ describe 'As a user, I want to manage my project kanban visualization' do
 
     expect(Grouping.count).to eq(2)
     expect(GroupingIssueAllocation.count).to eq(0)
-    expect(Issue.count).to eq(0)
+    expect(Issue.count).to eq(3)
   end
 
   specify 'I can move groupings on the kanban visualization page' do

--- a/spec/features/managing_kanban_spec.rb
+++ b/spec/features/managing_kanban_spec.rb
@@ -376,4 +376,28 @@ describe 'As a user, I want to manage my project kanban visualization' do
 
     expect(Issue.where(id: issue.id)).not_to be_present
   end
+
+  specify 'I can change issue grouping on the issue detail modal' do
+    project = FactoryBot.create(:project)
+    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization, title: "First grouping")
+    issue = FactoryBot.create(:issue, project: project, title: "Change grouping")
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+
+    FactoryBot.create(:grouping, visualization: project.default_visualization, title: "Second grouping")
+
+    visit visualization_path(project.default_visualization)
+
+    click_link "Change grouping"
+
+    find(".cpy-grouping-picker-button").click
+
+    within ".cpy-grouping-picker-container" do
+      click_link "Second grouping"
+    end
+
+    expect(page).to have_content("Issue column was successfully updated.")
+
+    issue.reload
+    expect(issue.grouping_issue_allocations.first.grouping.title).to eq("Second grouping")
+  end
 end

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -18,7 +18,10 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     FactoryBot.create(:issue, project: project, title: "First issue")
     FactoryBot.create(:issue, project: project, title: "Second issue")
-    FactoryBot.create(:issue, project: project, title: "Third issue")
+    issue = FactoryBot.create(:issue, project: project, title: "Third issue") do |issue|
+      grouping = FactoryBot.create(:grouping, title: "Custom grouping")
+      FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+    end
 
     visit project_issues_path(project)
 
@@ -27,6 +30,10 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     expect(page).to have_content("First issue")
     expect(page).to have_content("Second issue")
     expect(page).to have_content("Third issue")
+
+    within dom_id(issue) do
+      expect(page).to have_content("Custom grouping")
+    end
   end
 
   specify "I can filter issues by name" do


### PR DESCRIPTION
## Why?

While the workflow board shows which column each issue belongs, in the all issues view there was no such thing. More than that, when an issue is created, it defaults to a "No column" state. This means means it doesn't appear on the workflow board (yet :eyes:), and so we couldn't changs its column from there.

This PR fixes that! Now, you can change an issue’s column directly from the issue detail modal. No need to switch to the workflow board just to move it around! 

## How

- Add grouping picker on the issue detail, you can change the column just selecting another one from the dropdown list
- After the update, the issue detail is updated via turbo frame
- Add has_many association from issue to grouping through grouping_issue_allocations (Used mainly by ransack filter)

## Preview

![Column change](https://github.com/user-attachments/assets/57bb58dd-5895-4c42-b262-907428f90345)
