### PR TITLE
Fix: Issue and column removal broadcast

### DIFF
--- a/app/models/grouping_issue_allocation.rb
+++ b/app/models/grouping_issue_allocation.rb
@@ -19,4 +19,7 @@ class GroupingIssueAllocation < ApplicationRecord
   after_update_commit -> {
     Visualizations::AllocationsChannel.broadcast_update(self)
   }
+  after_destroy_commit -> {
+    issue.broadcast_remove_to grouping.visualization
+  }
 end

--- a/app/models/grouping_issue_allocation.rb
+++ b/app/models/grouping_issue_allocation.rb
@@ -20,6 +20,6 @@ class GroupingIssueAllocation < ApplicationRecord
     Visualizations::AllocationsChannel.broadcast_update(self)
   }
   after_destroy_commit -> {
-    issue.broadcast_remove_to grouping.visualization
+    issue.broadcast_remove_to grouping.visualization if grouping.present?
   }
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -53,7 +53,6 @@ class Issue < ApplicationRecord
       }
     )
   }
-  after_destroy_commit -> { broadcast_remove_to project.default_visualization }
 
   def to_param
     if persisted?

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -53,7 +53,7 @@ class Issue < ApplicationRecord
       }
     )
   }
-  after_destroy_commit -> { broadcast_remove_to "visualization" }
+  after_destroy_commit -> { broadcast_remove_to project.default_visualization }
 
   def to_param
     if persisted?


### PR DESCRIPTION
## Bug 1 - Issue not been removed from workflow board when removed on another tab

### Current behavior

When deleting an issue on one tab, the corresponding card was not removed from the workflow visualization on another tab

### Expected behavior

When deleting an issue on one tab, the corresponding card should also be removed from workflow visualization on another tab

## Bug 2 - Card not been removed from workflow board when column assigned is updated to "No column"

### Current behavior

When changing the assigned column to an issue on one tab, the corresponding issue was not removed from the workflow visualization on another tab (As there are no column for the issue to be)

### Expected behavior

When changing the assigned column to an issue on one tab, the corresponding issue should be removed from the workflow visualization on another tab

## Solution

There was a misconfigured after_destroy broadcast for the issue modal, however, instead of changing it for only issue events, we moved the broadcast to the allocation.

1. This means that when an issue is destroyed, so is the allocation, and then the removal broadcast happen.
2. Also, when the issue had an assigned column, but change to "No column", the allocation is removed, meaning the destroy broadcast also happen
3. Finally, when an column is destroyed, while there is no broadcast to happen, it would no longer be available for the destroy broadcast on the allocation, so a presence verification is required before triggering the event