### PR TITLE
Chore: Improve objectiveness

### DIFF
--- a/app/models/issue_label.rb
+++ b/app/models/issue_label.rb
@@ -12,16 +12,12 @@ class IssueLabel < ApplicationRecord
   # Validations
   validates :title, presence: true, uniqueness: { case_sensitive: false, scope: [ :project_id ] }
 
-  # Hooks
-  before_validation :strip_title_whitepaces
+  # Normalizations
+  normalizes :title, with: -> { _1.strip }
 
   # Ransack
   def self.ransackable_attributes(auth_object = nil)
     [ "title", "updated_at" ]
-  end
-
-  def strip_title_whitepaces
-    self.title = self.title&.strip
   end
 
   # Broadcasts

--- a/app/models/issue_label.rb
+++ b/app/models/issue_label.rb
@@ -1,7 +1,7 @@
 class IssueLabel < ApplicationRecord
   # Scopes
   default_scope { order(title: :asc) }
-  scope :with_title, ->(title) { where("lower(title) LIKE ?", title) }
+  scope :with_title, ->(title) { where("lower(title) LIKE :search", search: title.downcase) }
 
   # Relationships
   has_many :issue_links, class_name: "IssueLabelLink", dependent: :destroy


### PR DESCRIPTION
## Why?

This PR is just some little improvements on the `IssueLabel` model:

- Explicit downcase the `title` on the `with_title` to avoid problems with the SQLite `LIKE` that is case insensitive only for ASCII characters ([Reference](https://www.sqlite.org/lang_expr.html#the_like_glob_regexp_match_and_extract_operators))
- Change the manual normalization of label titles with the Rails 7 `ActiveRecord::Base.normalizes` ([Reference](https://www.bigbinary.com/blog/rails-7-1-adds-activerecord-base-normalizes))

## Note

While the `strip` is the desired normalization for the `title`, the downcase is not.

The reason for that is that we want to keep the original label case, as wrote by the user. So it should only be used for searches