### PR TITLE
Chore: Improve tests reliability

### DIFF
--- a/spec/features/project_management/kanban/using_favorite_labels_spec.rb
+++ b/spec/features/project_management/kanban/using_favorite_labels_spec.rb
@@ -26,6 +26,8 @@ describe 'As a project manager, I want to use favorite issue labels' do
 
     all(".cpy-keyboard-shortcuts form button")[0].click
 
+    expect(page).to have_content("Workflow Board was successfully updated.")
+
     visualization.reload
     expect(visualization.favorite_issue_labels).to eq([ "", "", 'Development', 'New Tag', "", "" ])
   end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -39,7 +39,7 @@ else
 
   Capybara.register_driver :chrome do |app|
     options   = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument("--window-size=1400,800")
+    options.add_argument("--window-size=1400,1000")
     options.add_argument("--no-sandbox")
 
     if ENV["CHROME_BINARY_PATH"].present?


### PR DESCRIPTION
## Why?

Once in a while tests fails, some times its our fault, others not exactly...

## Problem 1

Locally, I notice that some tests would break from time to time because the button was hidden behind some other element, which doesn't happen on the usual development cycle.

But what happen is that during development we usually use a full size windows, while Capybara use a fixed size window. So increasing it should probably improve reliability (3261bdce9a37791b45fdf7bce62f24cd176944e6)

## Problem 2

Another problem that happen from time to time is that a resource that should be updated, isn't. (spec/features/project_management/kanban/using_favorite_labels_spec.rb). This happen because we dispatch an action (click button/submit form) and while that is happening on the Browser (through Capybara), the test already go on, trying to reload the resource that isn't even updated.

To solve that, some methods forces Capybara to wait until something happen on the page, like a feedback message informing that the update was successfully. Using that we can make the test only reload the resource after we are sure the request was processed. (e6600f1a218c7278c0e09deac67ed86fb85912f7)