### PR TITLE
Custom message for empty search on "All Issues"

### DIFF
--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,5 +1,5 @@
 <%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "cpy-filter-form" do |f| %>
-  <div class="flex flex-col lg:flex-row justify-between items-stretch gap-4">
+  <div class="flex flex-col md:flex-row justify-between items-stretch gap-4">
     <div class="flex flex-col md:flex-row justify-start items-stretch gap-4">
       <div class="flex gap-2 md:w-60 items-center">
         <%= f.label :title_cont, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
@@ -7,7 +7,7 @@
       </div>
 
 
-      <div class="flex gap-2 md:grow lg:w-72 items-center cpy-by-labels-titles">
+      <div class="flex gap-2 md:grow md:w-72 items-center cpy-by-labels-titles">
         <%= f.label :by_label_titles, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
         <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
                   { include_hidden: false },

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -17,13 +17,21 @@
 
   <div class="flex flex-col gap-3 lg:gap-6 flex-wrap justify-stretch">
     <% if @issues.empty? %>
-      <div class="bg-body-contrast rounded-md border border-background-200 p-4 space-y-4 shadow-xs items-center">
-        <p class='text-center text-readable-content-500'>
-          <%= t("zero_records", resource_name: Issue.model_name.human) %>
-        </p>
-        <p class="mt-3 text-center mb-4">
-          <%= link_to t('click_here_to_create_one'), new_project_issue_path(current_project), class: "btn-primary inline-block", data: { turbo_frame: 'new_issue_form' } %>
-        </p>
+      <div class="bg-body-contrast flex flex-col rounded-md border border-background-200 p-4 space-y-4 shadow-xs items-center">
+        <% if params[:q].present? %>
+          <p class='text-center text-readable-content-500'>
+            <%= t("zero_records_for_this_search", resource_name: Issue.model_name.human) %>
+          </p>
+        <% else %>
+          <p class='text-center text-readable-content-500'>
+            <%= t("zero_records", resource_name: Issue.model_name.human) %>
+          </p>
+          <p class="mt-3 text-center mb-4">
+            <%= link_to t('click_here_to_create_one'), new_project_issue_path(current_project), class: "btn-primary inline-block", data: { turbo_frame: 'new_issue_form' } %>
+          </p>
+
+        <% end %>
+
       </div>
     <% else %>
       <table class="table-primary table-striped">

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -19,6 +19,7 @@ en:
   minutes: 'Minutes'
   click_here: 'Click here'
   zero_records: "You haven't created any %{resource_name} yet."
+  zero_records_for_this_search: "No records were found for your search."
   click_here_to_create_one: "Click here to create one"
   click_here_to_create_one_f: "Click here to create one"
   confirmations:

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -20,6 +20,7 @@ pt-BR:
   minutes: 'Minutos'
   click_here: 'Clique aqui'
   zero_records: "Você ainda não criou nenhum(a) %{resource_name}."
+  zero_records_for_this_search: "Nenhum registro foi encontrado para sua busca."
   click_here_to_create_one: "Clique aqui para criar um"
   click_here_to_create_one_f: "Clique aqui para criar uma"
   confirmations:

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -36,6 +36,20 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     end
   end
 
+  specify "There is a custom message for zero results when filtering" do
+    project = FactoryBot.create(:project, name: "Project Alpha")
+
+    visit project_issues_path(project)
+
+    within ".cpy-filter-form" do
+      fill_in 'q[title_cont]', with: "NOMATCH"
+
+      click_button "Search"
+    end
+
+    expect(page).to have_content("No records were found for your search.")
+  end
+
   specify "I can filter issues by name" do
     project = FactoryBot.create(:project)
 


### PR DESCRIPTION
This PR:

- adds a custom message if the search returns zero results.
- changes display breakpoint for the filters

<img width="883" alt="image" src="https://github.com/user-attachments/assets/3567255c-fc50-4f74-ad4b-1457497d0999" />
