### PR TITLE
Feat board column expand

### DIFF
--- a/app/controllers/visualizations/groupings_controller.rb
+++ b/app/controllers/visualizations/groupings_controller.rb
@@ -60,6 +60,6 @@ class Visualizations::GroupingsController < ApplicationController
   end
 
   def permitted_params
-    params.require(:grouping).permit(:title)
+    params.require(:grouping).permit(:title, :collapsed)
   end
 end

--- a/app/controllers/visualizations/groupings_controller.rb
+++ b/app/controllers/visualizations/groupings_controller.rb
@@ -60,6 +60,6 @@ class Visualizations::GroupingsController < ApplicationController
   end
 
   def permitted_params
-    params.require(:grouping).permit(:title, :collapsed)
+    params.require(:grouping).permit(:title, :hidden)
   end
 end

--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -7,14 +7,12 @@ export default class extends Controller {
     "cardContainer",
     "showFormButton",
     "inlineCardForm",
-    "inlineCardFormTitle",
-    "content"
+    "inlineCardFormTitle"
   ]
 
   static values = {
     scrollToOnConnect: Boolean,
-    groupingId: String,
-    collapsed: Boolean
+    groupingId: String
   }
 
   connect() {
@@ -120,11 +118,5 @@ export default class extends Controller {
 
       destinationCard.insertAdjacentElement('beforebegin', card)
     }
-  }
-
-  toggleCollapse() {
-    this.collapsedValue = !this.collapsedValue
-    this.contentTarget.classList.toggle('hidden')
-    this.element.style.width = this.collapsedValue ? '90px' : '256px'
   }
 }

--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -7,12 +7,14 @@ export default class extends Controller {
     "cardContainer",
     "showFormButton",
     "inlineCardForm",
-    "inlineCardFormTitle"
+    "inlineCardFormTitle",
+    "collapseButton"
   ]
 
   static values = {
     scrollToOnConnect: Boolean,
-    groupingId: String
+    groupingId: String,
+    collapsed: Boolean
   }
 
   connect() {
@@ -117,5 +119,10 @@ export default class extends Controller {
 
       destinationCard.insertAdjacentElement('beforebegin', card)
     }
+  }
+
+  toggleCollapse() {
+    this.collapsedValue = !this.collapsedValue
+    this.cardContainerTarget.classList.toggle('hidden')
   }
 }

--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
     "showFormButton",
     "inlineCardForm",
     "inlineCardFormTitle",
-    "collapseButton"
+    "content"
   ]
 
   static values = {
@@ -65,6 +65,7 @@ export default class extends Controller {
     e.stopPropagation()
     this.inlineCardFormTarget.requestSubmit()
   }
+
   closeForm() {
     this.hideInlineCardForm()
   }
@@ -123,6 +124,7 @@ export default class extends Controller {
 
   toggleCollapse() {
     this.collapsedValue = !this.collapsedValue
-    this.cardContainerTarget.classList.toggle('hidden')
+    this.contentTarget.classList.toggle('hidden')
+    this.element.style.width = this.collapsedValue ? '90px' : '256px'
   }
 }

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -12,8 +12,7 @@
   >
   <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
-          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap text-center' if grouping.hidden}",
-          style: "word-break: break-all;text-transform: uppercase;",
+          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap uppercase text-center text-uppcase break-all' if grouping.hidden}",
           data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
     <% end %>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,29 +1,28 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
 
 <li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> <%= 'collapsed' if grouping.hidden %> transition-all duration-200"
-  style="animation-duration: 240ms; width: <%= grouping.hidden ? '70px' : '256px' %>;"
+  style="animation-duration: 240ms; width: <%= grouping.hidden ? '50px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
   data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
   data-grouping-column-grouping-id-value="<%= grouping.id %>"
-  data-grouping-column-collapsed-value="<%= grouping.hidden %>"
   data-action="keypress.n@window->grouping-column#nWasPressed"
   data-visualization--board-target="column"
   >
-  <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
+  <header class="flex <%= grouping.hidden ? 'flex-col' : 'flex-row' %> flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
-          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap uppercase text-center text-uppcase break-all' if grouping.hidden}",
+          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap uppercase text-center break-all' if grouping.hidden}",
           data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
     <% end %>
 
-    <div class="flex flex-row gap-2 grow-0 shrink-0 relative">
+    <div class="flex <%= grouping.hidden ? 'order-first' : '' %> flex-row gap-4 grow-0 shrink-0 relative">
       <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { hidden: !grouping.hidden }),
-            class: "ml-2 text-readable-content-500 hover:text-readable-content-700 ",
+            class: "text-readable-content-500 hover:text-readable-content-700 ",
             data: {
               turbo_method: :patch
             } do %>
-        <i class="fa-solid <%= grouping.hidden ? 'fa-chevron-right' : 'fa-chevron-left' %>"></i>
+        <i class="fa-solid  <%= grouping.hidden ? 'fa-arrows-left-right-to-line' : 'fa-down-left-and-up-right-to-center rotate-45' %>"></i>
       <% end %>
 
       <button class="text-readable-content-500 cpy-column-menu-button <%= 'hidden' if grouping.hidden %>"

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -5,12 +5,23 @@
   data-controller="grouping-column"
   data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
   data-grouping-column-grouping-id-value="<%= grouping.id %>"
+  data-grouping-column-collapsed-value="<%= grouping.collapsed %>"
   data-action="keypress.n@window->grouping-column#nWasPressed"
   data-visualization--board-target="column"
   >
   <header class="flex flex-row flex-nowrap gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id), class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
+    <% end %>
+
+    <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
+          class: "text-readable-content-500 hover:text-readable-content-700 grow-0 shrink-0",
+          data: {
+            turbo_method: :patch,
+            grouping_column_target: "collapseButton",
+            action: "click->grouping-column#toggleCollapse"
+          } do %>
+      <i class="fa-solid <%= grouping.collapsed ? 'fa-chevron-down' : 'fa-chevron-up' %>"></i>
     <% end %>
 
     <button class="text-readable-content-500 grow-0 shrink-0 cpy-column-menu-button"
@@ -64,36 +75,38 @@
     </div>
   </header>
 
-  <ul
-    id="<%= grouping.id %>-cards-wrapper"
-    class="flex flex-col flex-auto flex-nowrap gap-y-2 items-stretch overflow-y-auto overflow-x-hidden scroll-smooth js-no-column-drag cpy-drop-zone"
-    data-controller="sortable"
-    data-sortable-target="container"
-    data-sortable-shared-group-value="cards"
-    data-sortable-move-path-value="<%= move_allocations_path %>"
-    data-sortable-grouping-id="<%= grouping.id %>"
-    data-grouping-column-target="cardContainer"
-    >
+  <div>
+    <ul
+      id="<%= grouping.id %>-cards-wrapper"
+      class="<%= 'hidden' if grouping.collapsed %>" flex flex-col flex-auto flex-nowrap gap-y-2 items-stretch overflow-y-auto overflow-x-hidden scroll-smooth js-no-column-drag cpy-drop-zone"
+      data-controller="sortable"
+      data-sortable-target="container"
+      data-sortable-shared-group-value="cards"
+      data-sortable-move-path-value="<%= move_allocations_path %>"
+      data-sortable-grouping-id="<%= grouping.id %>"
+      data-grouping-column-target="cardContainer"
+      >
 
-    <% grouping.issues.each do |issue| %>
-      <%= render partial: 'visualizations/card', locals: {
-        issue:,
-        visualization: ,
-        scroll_on_connect: local_assigns[:open_issue] == issue
-      } %>
-    <% end %>
-  </ul>
+      <% grouping.issues.each do |issue| %>
+        <%= render partial: 'visualizations/card', locals: {
+          issue:,
+          visualization: ,
+          scroll_on_connect: local_assigns[:open_issue] == issue
+        } %>
+      <% end %>
+    </ul>
 
-  <div class="sticky bottom-0 w-full">
-    <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping:, visualization: } %>
-    <button class="cpy-inline-create-button w-full group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
-      data-grouping-column-target="showFormButton"
-      data-action="click->grouping-column#showInlineCardForm">
-      <i class="fa-solid fa-plus mr-2"></i>
-      <p class="grow text-left">
-        <%= t('visualizations.column_menu.create_issue') %>
-      </p>
-      <span class="group-hover:flex hidden text-xs font-medium ml-2 mr-2"><%= t("actions.press") %> N</span>
-    </button>
+    <div class="sticky bottom-0 w-full">
+      <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping:, visualization: } %>
+      <button class="cpy-inline-create-button w-full group flex flex-row items-center mt-4 p-2 hover:bg-background-100 rounded-md"
+        data-grouping-column-target="showFormButton"
+        data-action="click->grouping-column#showInlineCardForm">
+        <i class="fa-solid fa-plus mr-2"></i>
+        <p class="grow text-left">
+          <%= t('visualizations.column_menu.create_issue') %>
+        </p>
+        <span class="group-hover:flex hidden text-xs font-medium ml-2 mr-2"><%= t("actions.press") %> N</span>
+      </button>
+    </div>
   </div>
 </li>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,6 +1,6 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
 <li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> transition-all duration-200"
-  style="animation-duration: 240ms; width: <%= grouping.collapsed ? '60px' : '256px' %>;"
+  style="animation-duration: 240ms; width: <%= grouping.collapsed ? '70px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
   data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
@@ -12,14 +12,14 @@
   <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
           class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap' if grouping.collapsed}",
-          style: "word-break: break-all;",
+          style: "word-break: break-all;text-transform: uppercase;",
           data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
     <% end %>
 
     <div class="flex flex-row gap-2 grow-0 shrink-0 relative">
       <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
-            class: "text-readable-content-500 hover:text-readable-content-700 ",
+            class: "ml-2 text-readable-content-500 hover:text-readable-content-700 ",
             data: {
               turbo_method: :patch,
               grouping_column_target: "collapseButton",
@@ -91,12 +91,14 @@
       data-grouping-column-target="cardContainer"
       >
 
-      <% grouping.issues.each do |issue| %>
-        <%= render partial: 'visualizations/card', locals: {
-          issue:,
-          visualization: ,
-          scroll_on_connect: local_assigns[:open_issue] == issue
-        } %>
+      <% unless grouping.collapsed %>
+        <% grouping.issues.each do |issue| %>
+          <%= render partial: 'visualizations/card', locals: {
+            issue:,
+            visualization: ,
+            scroll_on_connect: local_assigns[:open_issue] == issue
+          } %>
+        <% end %>
       <% end %>
     </ul>
 

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,5 +1,5 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
-<li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> transition-all duration-200"
+<li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> <%= 'collapsed' if grouping.collapsed %> transition-all duration-200"
   style="animation-duration: 240ms; width: <%= grouping.collapsed ? '70px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
@@ -11,7 +11,7 @@
   >
   <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
-          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap' if grouping.collapsed}",
+          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap text-center' if grouping.collapsed}",
           style: "word-break: break-all;text-transform: uppercase;",
           data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
@@ -21,9 +21,7 @@
       <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
             class: "ml-2 text-readable-content-500 hover:text-readable-content-700 ",
             data: {
-              turbo_method: :patch,
-              grouping_column_target: "collapseButton",
-              action: "click->grouping-column#toggleCollapse"
+              turbo_method: :patch
             } do %>
         <i class="fa-solid <%= grouping.collapsed ? 'fa-chevron-right' : 'fa-chevron-left' %>"></i>
       <% end %>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,6 +1,6 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
-<li class="max-h-full w-64 flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %>"
-  style="animation-duration: 240ms;"
+<li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> transition-all duration-200"
+  style="animation-duration: 240ms; width: <%= grouping.collapsed ? '60px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
   data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
@@ -9,43 +9,47 @@
   data-action="keypress.n@window->grouping-column#nWasPressed"
   data-visualization--board-target="column"
   >
-  <header class="flex flex-row flex-nowrap gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
-    <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id), class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700", data: { turbo_frame: 'grouping_form' } do %>
+  <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
+    <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
+          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap' if grouping.collapsed}",
+          style: "word-break: break-all;",
+          data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
     <% end %>
 
-    <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
-          class: "text-readable-content-500 hover:text-readable-content-700 grow-0 shrink-0",
-          data: {
-            turbo_method: :patch,
-            grouping_column_target: "collapseButton",
-            action: "click->grouping-column#toggleCollapse"
-          } do %>
-      <i class="fa-solid <%= grouping.collapsed ? 'fa-chevron-down' : 'fa-chevron-up' %>"></i>
-    <% end %>
+    <div class="flex flex-row gap-2 grow-0 shrink-0 relative">
+      <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
+            class: "text-readable-content-500 hover:text-readable-content-700 ",
+            data: {
+              turbo_method: :patch,
+              grouping_column_target: "collapseButton",
+              action: "click->grouping-column#toggleCollapse"
+            } do %>
+        <i class="fa-solid <%= grouping.collapsed ? 'fa-chevron-right' : 'fa-chevron-left' %>"></i>
+      <% end %>
 
-    <button class="text-readable-content-500 grow-0 shrink-0 cpy-column-menu-button"
-            data-action="click->dropdown#toggle click@window->dropdown#hide"
-            data-dropdown-target="button"
-            role="button"
-            aria-haspopup="true"
-            aria-expanded="false">
-      <i class="fa-solid fa-ellipsis"></i>
-    </button>
+      <button class="text-readable-content-500 cpy-column-menu-button <%= 'hidden' if grouping.collapsed %>"
+              data-action="click->dropdown#toggle click@window->dropdown#hide"
+              data-dropdown-target="button"
+              role="button"
+              aria-haspopup="true"
+              aria-expanded="false">
+        <i class="fa-solid fa-ellipsis"></i>
+      </button>
 
-    <div class="bg-body-contrast z-10 absolute -left-2 top-full min-w-60 border border-background-100 rounded-lg shadow-lg overflow-hidden hidden cpy-column-menu"
-      data-dropdown-target="menu">
-      <div class="flex flex-col justify-stretch items-stretch text-sm text-left py-2">
-        <div class="flex flex-row py-2 relative">
-          <h3 class="mx-auto">
-            <%= t('visualizations.column_menu.actions') %>
-          </h3>
-          <button class="absolute right-0 mr-4"
-                  data-action="click->dropdown#toggle"
-                  >
-            <i class="fa-solid fa-xmark"></i>
-          </button>
-        </div>
+      <div class="bg-body-contrast z-10 absolute -right-2 top-full min-w-60 border border-background-100 rounded-lg shadow-lg overflow-hidden hidden cpy-column-menu"
+        data-dropdown-target="menu">
+        <div class="flex flex-col justify-stretch items-stretch text-sm text-left py-2">
+          <div class="flex flex-row py-2 relative">
+            <h3 class="mx-auto">
+              <%= t('visualizations.column_menu.actions') %>
+            </h3>
+            <button class="absolute right-0 mr-4"
+                    data-action="click->dropdown#toggle"
+                    >
+              <i class="fa-solid fa-xmark"></i>
+            </button>
+          </div>
 
         <div class="flex flex-col mt-2 justify-stretch items-stretch">
           <div class="flex flex-col justify-stretch border-b border-background-100 pb-2 mb-2">
@@ -75,10 +79,10 @@
     </div>
   </header>
 
-  <div>
+  <div data-grouping-column-target="content" class="flex-1 flex flex-col <%= 'hidden' if grouping.collapsed %>">
     <ul
       id="<%= grouping.id %>-cards-wrapper"
-      class="<%= 'hidden' if grouping.collapsed %>" flex flex-col flex-auto flex-nowrap gap-y-2 items-stretch overflow-y-auto overflow-x-hidden scroll-smooth js-no-column-drag cpy-drop-zone"
+      class="flex flex-col flex-auto flex-nowrap gap-y-2 items-stretch overflow-y-auto overflow-x-hidden scroll-smooth js-no-column-drag cpy-drop-zone"
       data-controller="sortable"
       data-sortable-target="container"
       data-sortable-shared-group-value="cards"

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,4 +1,5 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
+
 <li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> <%= 'collapsed' if grouping.hidden %> transition-all duration-200"
   style="animation-duration: 240ms; width: <%= grouping.hidden ? '70px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -1,32 +1,32 @@
 <% animation_css = local_assigns[:recently_created] ? "animate__animated animate__zoomIn" : "" %>
-<li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> <%= 'collapsed' if grouping.collapsed %> transition-all duration-200"
-  style="animation-duration: 240ms; width: <%= grouping.collapsed ? '70px' : '256px' %>;"
+<li class="max-h-full flex flex-col shrink-0 p-2 border bg-body-contrast border-background-100 rounded-md shadow-xs cpy-grouping js-sortable-container <%= animation_css %> <%= 'collapsed' if grouping.hidden %> transition-all duration-200"
+  style="animation-duration: 240ms; width: <%= grouping.hidden ? '70px' : '256px' %>;"
   id="<%= dom_id(grouping) %>"
   data-controller="grouping-column"
   data-grouping-column-scroll-to-on-connect-value="<%= local_assigns[:recently_created] == true %>"
   data-grouping-column-grouping-id-value="<%= grouping.id %>"
-  data-grouping-column-collapsed-value="<%= grouping.collapsed %>"
+  data-grouping-column-collapsed-value="<%= grouping.hidden %>"
   data-action="keypress.n@window->grouping-column#nWasPressed"
   data-visualization--board-target="column"
   >
   <header class="flex flex-row flex-nowrap justify-between items-center gap-x-1 mb-4 px-2 relative" data-controller="dropdown">
     <%= link_to edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
-          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap text-center' if grouping.collapsed}",
+          class: "grow font-semibold truncate text-readable-content-500 hover:text-readable-content-700 #{'text-wrap text-center' if grouping.hidden}",
           style: "word-break: break-all;text-transform: uppercase;",
           data: { turbo_frame: 'grouping_form' } do %>
       <%= grouping.title %>
     <% end %>
 
     <div class="flex flex-row gap-2 grow-0 shrink-0 relative">
-      <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { collapsed: !grouping.collapsed }),
+      <%= link_to visualization_grouping_path(grouping.visualization_id, grouping, grouping: { hidden: !grouping.hidden }),
             class: "ml-2 text-readable-content-500 hover:text-readable-content-700 ",
             data: {
               turbo_method: :patch
             } do %>
-        <i class="fa-solid <%= grouping.collapsed ? 'fa-chevron-right' : 'fa-chevron-left' %>"></i>
+        <i class="fa-solid <%= grouping.hidden ? 'fa-chevron-right' : 'fa-chevron-left' %>"></i>
       <% end %>
 
-      <button class="text-readable-content-500 cpy-column-menu-button <%= 'hidden' if grouping.collapsed %>"
+      <button class="text-readable-content-500 cpy-column-menu-button <%= 'hidden' if grouping.hidden %>"
               data-action="click->dropdown#toggle click@window->dropdown#hide"
               data-dropdown-target="button"
               role="button"
@@ -77,7 +77,7 @@
     </div>
   </header>
 
-  <div data-grouping-column-target="content" class="flex-1 flex flex-col <%= 'hidden' if grouping.collapsed %>">
+  <div data-grouping-column-target="content" class="flex-1 flex flex-col <%= 'hidden' if grouping.hidden %>">
     <ul
       id="<%= grouping.id %>-cards-wrapper"
       class="flex flex-col flex-auto flex-nowrap gap-y-2 items-stretch overflow-y-auto overflow-x-hidden scroll-smooth js-no-column-drag cpy-drop-zone"
@@ -89,7 +89,7 @@
       data-grouping-column-target="cardContainer"
       >
 
-      <% unless grouping.collapsed %>
+      <% unless grouping.hidden %>
         <% grouping.issues.each do |issue| %>
           <%= render partial: 'visualizations/card', locals: {
             issue:,

--- a/db/migrate/20250228114444_add_collapsed_to_groupings.rb
+++ b/db/migrate/20250228114444_add_collapsed_to_groupings.rb
@@ -1,0 +1,5 @@
+class AddCollapsedToGroupings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :groupings, :collapsed, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20250228114444_add_collapsed_to_groupings.rb
+++ b/db/migrate/20250228114444_add_collapsed_to_groupings.rb
@@ -1,5 +1,0 @@
-class AddCollapsedToGroupings < ActiveRecord::Migration[8.0]
-  def change
-    add_column :groupings, :collapsed, :boolean, null: false, default: false
-  end
-end

--- a/db/migrate/20250228114444_add_hidden_to_groupings.rb
+++ b/db/migrate/20250228114444_add_hidden_to_groupings.rb
@@ -1,0 +1,5 @@
+class AddHiddenToGroupings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :groupings, :hidden, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_09_120105) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_28_114444) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -62,6 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_09_120105) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position", null: false
+    t.boolean "collapsed", default: false, null: false
     t.index ["visualization_id", "position"], name: "index_groupings_on_visualization_id_and_position", unique: true
     t.index ["visualization_id"], name: "index_groupings_on_visualization_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_28_114444) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "position", null: false
-    t.boolean "collapsed", default: false, null: false
+    t.boolean "hidden", default: false, null: false
     t.index ["visualization_id", "position"], name: "index_groupings_on_visualization_id_and_position", unique: true
     t.index ["visualization_id"], name: "index_groupings_on_visualization_id"
   end

--- a/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
+++ b/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
@@ -27,7 +27,8 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
       expect(page).to have_css('.fa-chevron-right')
     end
 
-    expect(grouping_todo.reload.hidden).to be_true
+
+    expect(grouping_todo.reload.hidden).to be true
   end
 
   specify 'I can expand a previously collapsed column' do
@@ -46,7 +47,7 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
       expect(page).to have_css('.fa-chevron-left')
     end
 
-    expect(grouping_todo.reload.hidden).to be_false
+    expect(grouping_todo.reload.hidden).to be false
   end
 
   specify 'Multiple columns can be collapsed independently' do

--- a/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
+++ b/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
@@ -19,12 +19,12 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
     within dom_id(grouping_todo) do
       expect(page).to have_content("Test issue")
 
-      find('.fa-chevron-left').click
+      find('.fa-down-left-and-up-right-to-center').click
     end
 
     within "#{dom_id(grouping_todo)}.collapsed" do
       expect(page).to_not have_content("Test issue")
-      expect(page).to have_css('.fa-chevron-right')
+      expect(page).to have_css('.fa-arrows-left-right-to-line')
     end
 
     expect(grouping_todo.reload.hidden).to be true
@@ -38,12 +38,12 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
     within "#{dom_id(grouping_todo)}.collapsed" do
       expect(page).to_not have_content("Test issue")
 
-      find('.fa-chevron-right').click
+      find('.fa-arrows-left-right-to-line').click
     end
 
     within dom_id(grouping_todo) do
       expect(page).to have_content("Test issue")
-      expect(page).to have_css('.fa-chevron-left')
+      expect(page).to have_css('.fa-down-left-and-up-right-to-center')
     end
 
     expect(grouping_todo.reload.hidden).to be false

--- a/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
+++ b/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe 'As a user, I want to collapse and expand columns on my kanban board' do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:project) { FactoryBot.create(:project) }
+  let!(:visualization) { project.default_visualization }
+  let!(:grouping_todo) { FactoryBot.create(:grouping, visualization: visualization, title: "TODO") }
+  let!(:grouping_doing) { FactoryBot.create(:grouping, visualization: visualization, title: "DOING") }
+  let!(:grouping_done) { FactoryBot.create(:grouping, visualization: visualization, title: "DONE") }
+  let!(:issue) { FactoryBot.create(:issue, title: "Test issue", project: project) }
+
+  before(:each) do
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping_todo)
+  end
+
+  specify 'I can collapse a column' do
+    visit visualization_path(visualization)
+
+    within dom_id(grouping_todo) do
+      expect(page).to have_content("Test issue")
+
+      find('.fa-chevron-left').click
+    end
+
+    within "#{dom_id(grouping_todo)}.collapsed" do
+      expect(page).to_not have_content("Test issue")
+      expect(page).to have_css('.fa-chevron-right')
+    end
+
+    expect(grouping_todo.reload.collapsed).to be_true
+  end
+
+  specify 'I can expand a previously collapsed column' do
+    grouping_todo.update!(collapsed: true)
+
+    visit visualization_path(visualization)
+
+    within "#{dom_id(grouping_todo)}.collapsed" do
+      expect(page).to_not have_content("Test issue")
+
+      find('.fa-chevron-right').click
+    end
+
+    within dom_id(grouping_todo) do
+      expect(page).to have_content("Test issue")
+      expect(page).to have_css('.fa-chevron-left')
+    end
+
+    expect(grouping_todo.reload.collapsed).to be_false
+  end
+
+  specify 'Multiple columns can be collapsed independently' do
+    grouping_todo.update!(collapsed: true)
+    grouping_done.update!(collapsed: true)
+
+    visit visualization_path(visualization)
+
+    expect(page).to have_selector("#{dom_id(grouping_todo)}.collapsed")
+
+    expect(page).to_not have_selector("#{dom_id(grouping_doing)}.collapsed")
+
+    expect(page).to have_selector("#{dom_id(grouping_done)}.collapsed")
+  end
+end

--- a/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
+++ b/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
@@ -27,11 +27,11 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
       expect(page).to have_css('.fa-chevron-right')
     end
 
-    expect(grouping_todo.reload.collapsed).to be_true
+    expect(grouping_todo.reload.hidden).to be_true
   end
 
   specify 'I can expand a previously collapsed column' do
-    grouping_todo.update!(collapsed: true)
+    grouping_todo.update!(hidden: true)
 
     visit visualization_path(visualization)
 
@@ -46,12 +46,12 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
       expect(page).to have_css('.fa-chevron-left')
     end
 
-    expect(grouping_todo.reload.collapsed).to be_false
+    expect(grouping_todo.reload.hidden).to be_false
   end
 
   specify 'Multiple columns can be collapsed independently' do
-    grouping_todo.update!(collapsed: true)
-    grouping_done.update!(collapsed: true)
+    grouping_todo.update!(hidden: true)
+    grouping_done.update!(hidden: true)
 
     visit visualization_path(visualization)
 

--- a/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
+++ b/spec/features/project_management/using_views/kanban/collapsable_columns_spec.rb
@@ -27,7 +27,6 @@ describe 'As a user, I want to collapse and expand columns on my kanban board' d
       expect(page).to have_css('.fa-chevron-right')
     end
 
-
     expect(grouping_todo.reload.hidden).to be true
   end
 


### PR DESCRIPTION
# Collapsible Board Columns
Now you can collapse columns that you're not actively using. More Space, Less Clutter! 

# Why
Sometimes you only need to focus on specific columns (like "TODO/DOING/DONE") while having other columns such as "Release 1 - Backlog", "Release 2 - Backlog", "Finished Items" etc. 

Large projects with many columns can become overwhelming and require horizontal scrolling so this feature comes into hand to solve this issue. 

# How
- Added a collapse/expand toggle button in each column's header
- Column titles rotate vertically when collapsed to maintain readability
- Issues are not rendered for collapsed columns
- The collapse behavior is propagated in real time to other clients

# Considerations
- In the next PR we will refactor the board style to a dedicated CSS component and use just a 'board-collapsed' css class to hide/show elements
- Dropping a card in a collapsed column is not allowed

![column-collapse](https://github.com/user-attachments/assets/d1a198fa-8082-4825-8dc7-eb9a351a178c)

## Pending
- Solve Merge conflicts with https://github.com/Eigenfocus/eigenfocus/pull/81 
