### PR TITLE
Onboarding Example Project & Quick Time Tracking

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -8,8 +8,13 @@ class ProfilesController < ApplicationController
     was_first_update = !current_user.is_profile_complete?
     if current_user.update(user_params)
       I18n.locale = current_user.locale
+
+      if was_first_update
+        ExampleProjectCreator.()
+      end
+
       flash[:success] = t(".success")
-      redirect_to root_path(show_guide_modal: was_first_update)
+      redirect_to root_path
     else
       flash[:alert] = current_user.errors.full_messages.to_sentence
       redirect_to edit_profile_path

--- a/app/services/example_project_creator.rb
+++ b/app/services/example_project_creator.rb
@@ -22,7 +22,7 @@ class ExampleProjectCreator
 
   def create_project!
     @project = Project.create!(
-      name: "Eigenfocus - Tour Project",
+      name: t("project.name"),
       time_tracking_enabled: true
     )
   end
@@ -34,62 +34,63 @@ class ExampleProjectCreator
   end
 
   def create_groupings!
-    @to_do = @visualization.groupings.create!(title: "To Do")
-    @in_progress = @visualization.groupings.create!(title: "In Progress")
-    @done = @visualization.groupings.create!(title: "Done")
+    @to_do = @visualization.groupings.create!(
+      title: t("groupings.to_do")
+    )
+    @in_progress = @visualization.groupings.create!(
+      title: t("groupings.in_progress")
+    )
+    @done = @visualization.groupings.create!(
+      title: t("groupings.done")
+    )
   end
 
   def create_tutorial_issues!
     # Create completed issues
     create_issue!(
-      "Create a new project",
-      "You've already completed this step! The project was created automatically for you.",
+      "create_project",
       @done
     )
 
     create_issue!(
-      "Enter the project board",
-      "You're already here! This board view helps you organize your issues in columns.",
+      "enter_board",
       @done
     )
 
     # Create in-progress issues
     create_issue!(
-      "Move an issue from In Progress to Done",
-      "Try dragging this card to the Done column. You can move any issue between columns to track its progress.",
+      "move_issue",
       @in_progress
     )
 
     # Create todo issues
     create_issue!(
-      "Create a new issue",
-      "Click the + button at the bottom of any column to create a new issue.",
+      "create_issue",
       @to_do
     )
 
     create_issue!(
-      "Open the issue card",
-      "Click on any issue card to see its details. You can:\n\n" \
-      "- Add labels to categorize your issues\n" \
-      "- Upload files and attachments\n" \
-      "- Add detailed descriptions using markdown",
+      "open_issue",
       @to_do
     )
 
     create_issue!(
-      "Start tracking time",
-      "Time tracking helps you monitor how long you spend on each task. Click the Track Time button to start tracking time.",
+      "track_time",
       @to_do
     )
   end
 
-  def create_issue!(title, description, grouping)
+  def create_issue!(issue_key, grouping)
     issue = @project.issues.create!(
-      title: title,
-      description: description
+      title: t("issues.#{issue_key}.title"),
+      description: t("issues.#{issue_key}.description")
     )
 
     grouping.allocate_issue(issue)
     issue
+  end
+
+  private def t(key)
+    I18n.t(key, scope: "examples.project_template")
   end
 end

--- a/app/services/example_project_creator.rb
+++ b/app/services/example_project_creator.rb
@@ -1,0 +1,95 @@
+class ExampleProjectCreator
+  def self.call
+    new.()
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      create_project!
+      create_visualization!
+      create_groupings!
+      create_tutorial_issues!
+    end
+
+    @to_do.update(position: 1)
+    @in_progress.update(position: 2)
+    @done.update(position: 3)
+  end
+
+  private
+
+  attr_reader :user
+
+  def create_project!
+    @project = Project.create!(
+      name: "Eigenfocus - Tour Project",
+      time_tracking_enabled: true
+    )
+  end
+
+  def create_visualization!
+    @visualization = @project.visualizations.create!(
+      type: "board"
+    )
+  end
+
+  def create_groupings!
+    @to_do = @visualization.groupings.create!(title: "To Do")
+    @in_progress = @visualization.groupings.create!(title: "In Progress")
+    @done = @visualization.groupings.create!(title: "Done")
+  end
+
+  def create_tutorial_issues!
+    # Create completed issues
+    create_issue!(
+      "Create a new project",
+      "You've already completed this step! The project was created automatically for you.",
+      @done
+    )
+
+    create_issue!(
+      "Enter the project board",
+      "You're already here! This board view helps you organize your issues in columns.",
+      @done
+    )
+
+    # Create in-progress issues
+    create_issue!(
+      "Move an issue from In Progress to Done",
+      "Try dragging this card to the Done column. You can move any issue between columns to track its progress.",
+      @in_progress
+    )
+
+    # Create todo issues
+    create_issue!(
+      "Create a new issue",
+      "Click the + button at the bottom of any column to create a new issue.",
+      @to_do
+    )
+
+    create_issue!(
+      "Open the issue card",
+      "Click on any issue card to see its details. You can:\n\n" \
+      "- Add labels to categorize your issues\n" \
+      "- Upload files and attachments\n" \
+      "- Add detailed descriptions using markdown",
+      @to_do
+    )
+
+    create_issue!(
+      "Start tracking time",
+      "Time tracking helps you monitor how long you spend on each task. Click the Track Time button to start tracking time.",
+      @to_do
+    )
+  end
+
+  def create_issue!(title, description, grouping)
+    issue = @project.issues.create!(
+      title: title,
+      description: description
+    )
+
+    grouping.allocate_issue(issue)
+    issue
+  end
+end

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -12,7 +12,7 @@
   <% data.merge!("issue-detail-attach-path-value": attach_issue_file_path(issue)) if issue.persisted? %>
 
   <%= render_modal(inner_container_options: {
-    class: "max-h-screen w-full max-w-4xl relative cpy-issue-detail",
+    class: "max-h-screen w-full max-w-3xl relative cpy-issue-detail",
     data: data
   }) do %>
     <div data-controller="dropzone" data-action="dropzone:complete->issue-detail#fileUploadCompleted">
@@ -52,9 +52,6 @@
               </div>
             </div>
 
-            <% if issue.persisted? && issue.project.default_visualization.groupings.present? %>
-              <%= render partial: 'issues/issue_detail/grouping_picker', locals: { issue: issue } %>
-            <% end %>
 
             <% if issue.persisted? %>
               <div data-controller='issue--labels'
@@ -89,13 +86,24 @@
           <% end %>
         </div>
         <% if issue.persisted? %>
-          <div class="flex flex-col gap-2 text-sm font-medium text-readable-content-700 text-center">
-            <h5 class="w-full"><%= t("menu.actions") %></h5>
+          <div class="flex flex-col gap-2 items-stretch w-1/4 text-sm font-medium text-readable-content-700 text-left">
 
-            <%= link_to destroy_path, class: "btn-danger text-center inline-flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
-              <i class="fa-solid fa-trash"></i>
-              <%= t("actions.remove") %>
+            <% if issue.persisted? && issue.project.default_visualization.groupings.present? %>
+              <%= render partial: 'issues/issue_detail/grouping_picker', locals: { issue: issue } %>
             <% end %>
+
+            <%= link_to time_entries_path(new_entry: { project_id: issue.project_id, issue_id: issue.id }), class: "mt-8 btn-outline-primary text-nowrap flex items-center py-2", data: { turbo_frame: "_top" } do %>
+              <span class="mr-2"><%= icon_for(:time_entries) %></span>
+              <span class="sm:block"><%= t("actions.start_time_tracking") %></span>
+            <% end %>
+
+            <div class="mt-4 flex flex-col items-stretch">
+              <h5 class="w-full mb-2"><%= t("menu.actions") %></h5>
+              <%= link_to destroy_path, class: "btn-danger flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
+                <i class="fa-solid fa-trash"></i>
+                <%= t("actions.remove") %>
+              <% end %>
+            </div>
           </div>
         <% end %>
 

--- a/app/views/issues/issue_detail/_grouping_picker.html.erb
+++ b/app/views/issues/issue_detail/_grouping_picker.html.erb
@@ -1,9 +1,9 @@
 <%= turbo_frame_tag 'issue_grouping_picker' do %>
-  <div class="mb-2 flex text-sm items-center gap-2" data-controller="dropdown">
+  <div class="mb-2 flex flex-col items-stretch text-sm items-center gap-2" data-controller="dropdown">
     <span><%= t(".in_grouping") %></span>
 
     <div
-      class="relative flex cpy-grouping-picker-button"
+      class="relative flex justify-stretch cpy-grouping-picker-button"
       data-action="click->dropdown#toggle click@window->dropdown#hide"
       role="button" aria-haspopup="true" aria-expanded="false"
       data-dropdown-target="button"

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -6,6 +6,7 @@
   <%
     new_entry = TimeEntry.new
     new_entry.project = Project.find(params[:new_entry][:project_id])
+    new_entry.issue = new_entry.project.issues.find_by_id(params[:new_entry][:issue_id])
     new_entry.reference_date = @reference_date
   %>
   <%= render partial: 'form', locals: { time_entry: new_entry } %>

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -63,6 +63,7 @@ en:
     go_to_issue: 'Go to Issue'
     go_to_issues_list: 'Go to issues list'
     go_to_time_tracking: "Go to time tracking"
+    start_time_tracking: "Start time tracking"
   flash:
     change_success: "Change successfully made."
     change_error: "Change could not be made."

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -63,7 +63,7 @@ en:
     go_to_issue: 'Go to Issue'
     go_to_issues_list: 'Go to issues list'
     go_to_time_tracking: "Go to time tracking"
-    start_time_tracking: "Start time tracking"
+    start_time_tracking: "Track time"
   flash:
     change_success: "Change successfully made."
     change_error: "Change could not be made."

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -64,6 +64,7 @@ pt-BR:
     go_to_issue: 'Ir para issue'
     go_to_issues_list: 'Ir para lista de issues'
     go_to_time_tracking: "Ir para registro de tempo"
+    start_time_tracking: "Iniciar registro de tempo"
   flash:
     change_success: "Alteração feita com sucesso."
     change_error: "Houve um erro na hora de realizar a alteração."

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -64,7 +64,7 @@ pt-BR:
     go_to_issue: 'Ir para issue'
     go_to_issues_list: 'Ir para lista de issues'
     go_to_time_tracking: "Ir para registro de tempo"
-    start_time_tracking: "Iniciar registro de tempo"
+    start_time_tracking: "Registrar tempo"
   flash:
     change_success: "Alteração feita com sucesso."
     change_error: "Houve um erro na hora de realizar a alteração."

--- a/config/locales/examples/project.en.yml
+++ b/config/locales/examples/project.en.yml
@@ -1,0 +1,33 @@
+en:
+  examples:
+    project_template:
+      project:
+        name: "Eigenfocus - Tour Example Project"
+      groupings:
+        to_do: "To Do"
+        in_progress: "In Progress"
+        done: "Done"
+      issues:
+        create_project:
+          title: "Create a new project"
+          description: "You've already completed this step! The project was created automatically for you."
+        enter_board:
+          title: "Enter the project board"
+          description: "You're already here! This board view helps you organize your issues in columns."
+        move_issue:
+          title: "Move an issue from In Progress to Done"
+          description: "Try dragging this card to the Done column. You can move any issue between columns to track its progress."
+        create_issue:
+          title: "Create a new issue"
+          description: "Click the + button at the bottom of any column to create a new issue."
+        open_issue:
+          title: "Open the issue card"
+          description: |
+            Click on any issue card to see its details. You can:
+
+            - Add labels to categorize your issues
+            - Upload files and attachments
+            - Add detailed descriptions using markdown
+        track_time:
+          title: "Start tracking time"
+          description: "Time tracking helps you monitor how long you spend on each task. Click the 'Track time' to test it out."

--- a/config/locales/examples/project.pt-BR.yml
+++ b/config/locales/examples/project.pt-BR.yml
@@ -1,0 +1,32 @@
+pt-BR:
+  examples:
+    project_template:
+      project:
+      name: "Eigenfocus - Projeto de Exemplo"
+      groupings:
+        to_do: "Pendente"
+        in_progress: "Em Andamento"
+        done: "Concluído"
+      issues:
+        create_project:
+          title: "Criar um novo projeto"
+          description: "Você já completou esta etapa! O projeto foi criado automaticamente para você."
+        enter_board:
+          title: "Entrar no quadro do projeto"
+          description: "Você já está aqui! Esta visualização de quadro te ajuda a organizar suas issues em colunas."
+        move_issue:
+          title: "Mover uma issue de Em Andamento para Concluído"
+          description: "Tente arrastar este cartão para a coluna Concluído. Você pode mover qualquer issue entre as colunas para acompanhar seu progresso."
+        create_issue:
+          title: "Criar uma nova issue"
+          description: "Clique no botão + na parte inferior de qualquer coluna para criar uma nova issue."
+        open_issue:
+          title: "Abrir o cartão da issue"
+          description: |
+            Clique em qualquer cartão de issue para ver seus detalhes. Você pode:
+            - Adicionar labels (etiquetas) para categorizar suas issues
+            - Fazer upload de arquivos e anexos
+            - Adicionar descrições detalhadas usando markdown
+        track_time:
+          title: "Começar a registrar tempo"
+          description: "O registro de tempo ajuda você a monitorar quanto tempo gasta em cada tarefa. Clique em 'Registrar tempo' para testar."

--- a/spec/features/managing_profile_spec.rb
+++ b/spec/features/managing_profile_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 describe 'When entering my workspace for the first time' do
   specify "I should be direct to edit a new profile" do
     expect(User.count).to eq(0)
+    expect(Project.count).to eq(0)
 
     visit projects_path
 
@@ -21,9 +22,11 @@ describe 'When entering my workspace for the first time' do
 
     should_be_on root_path
 
-    expect(page).to have_content("Here is an overview of our current features.")
-  end
+    project = Project.first
+    expect(project.name).to eq("Eigenfocus - Tour Project")
 
+    expect(page).to have_content("Eigenfocus - Tour Project")
+  end
 
   specify "I can update my profile" do
     user = FactoryBot.create(:user, timezone: 'Cairo')
@@ -42,5 +45,8 @@ describe 'When entering my workspace for the first time' do
     user.reload
     expect(user.timezone).to eq('Rome')
     expect(page).to have_content("Profile succesfully updated.")
+
+    # Verify no example project is created on subsequent updates
+    expect(Project.count).to eq(0)
   end
 end

--- a/spec/features/managing_profile_spec.rb
+++ b/spec/features/managing_profile_spec.rb
@@ -23,9 +23,9 @@ describe 'When entering my workspace for the first time' do
     should_be_on root_path
 
     project = Project.first
-    expect(project.name).to eq("Eigenfocus - Tour Project")
+    expect(project.name).to eq("Eigenfocus - Tour Example Project")
 
-    expect(page).to have_content("Eigenfocus - Tour Project")
+    expect(page).to have_content("Eigenfocus - Tour Example Project")
   end
 
   specify "I can update my profile" do

--- a/spec/features/managing_projects_spec.rb
+++ b/spec/features/managing_projects_spec.rb
@@ -114,6 +114,6 @@ context "As a user, I want to manage my projects" do
       )
     end
 
-    should_be_on(time_entries_path)
+    should_be_on(time_entries_path(new_entry: { project_id: project_beta.id }))
   end
 end

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -197,4 +197,24 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     expect(Issue.where(id: issue.id)).not_to be_present
   end
+
+  specify "I can start time tracking for an issue" do
+    project = FactoryBot.create(:project)
+
+    issue = FactoryBot.create(:issue, title: "Issue testing title", project: project)
+
+    visit project_issues_path(project)
+
+    within dom_id(issue) do
+      find(".cpy-edit-button").click
+    end
+
+    within ".cpy-issue-detail" do
+      click_link "Start time tracking"
+    end
+
+    expect(page).to have_content("Create Time entry")
+
+    should_be_on(time_entries_path(new_entry: { project_id: project.id, issue_id: issue.id }))
+  end
 end

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -210,7 +210,7 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     end
 
     within ".cpy-issue-detail" do
-      click_link "Start time tracking"
+      click_link "Track time"
     end
 
     expect(page).to have_content("Create Time entry")

--- a/spec/support/helpers/should_be_on.rb
+++ b/spec/support/helpers/should_be_on.rb
@@ -2,11 +2,11 @@
 module RSpec::Helpers
   module Features
     def should_be_on(path)
-      expect(URI.parse(current_url).path).to eq(path)
+      expect(URI.parse(current_url).request_uri).to eq(path)
     end
 
     def should_not_be_on(path)
-      expect(URI.parse(current_url).path).to_not eq(path)
+      expect(URI.parse(current_url).request_uri).to_not eq(path)
     end
   end
 end


### PR DESCRIPTION
This PR introduces a key feature to improve user experience during onboarding

# Example Tour Project
When the user user complete their profile for the first time, we now automatically create an example project that serves as an interactive tutorial. 

![image](https://github.com/user-attachments/assets/4e93b402-a0c5-47fe-8f56-bbafac5245c8)

# Issue modal - Time tracking
- Reduced modal width
- Added a "Start Time tracking" button (this can be improved in the future when we implement the current running time entries)
- Moved the column change select picker to the right

![image](https://github.com/user-attachments/assets/bbf389c4-67ad-4ad6-b002-d8137d509e71)

# Other
- Updated should_be_on spec helper method to include querystring

