### PR TITLE
Apply labels from issue create modal

### DIFF
--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -20,7 +20,7 @@ class Projects::IssuesController < ApplicationController
   end
 
   def new
-    @issue = Issue.new
+    @issue = current_project.issues.new
   end
 
   def create
@@ -31,7 +31,8 @@ class Projects::IssuesController < ApplicationController
     else
       render turbo_stream: turbo_stream.replace(
         "new_issue_form",
-        partial: "issues/create", locals: { issue: @issue }
+        partial: "issues/create", locals: { issue: @issue,
+        create_issue_url: project_issues_path(current_project) }
       )
     end
   end
@@ -72,6 +73,6 @@ class Projects::IssuesController < ApplicationController
   end
 
   def permitted_params
-    params.require(:issue).permit(:title, :description, files: [])
+    params.require(:issue).permit(:title, :description, files: [], labels_list: [])
   end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -59,4 +59,28 @@ class Issue < ApplicationRecord
       [ id, title.parameterize ].join("-")
     end
   end
+
+  def labels_list=(labels_input)
+    return if labels_input.blank?
+
+    label_titles = if labels_input.is_a?(Array)
+      labels_input
+    else
+      labels_input.split(",").map(&:strip)
+    end
+
+    @labels_list = label_titles.reject(&:blank?)
+  end
+
+  def labels_list
+    @labels_list || labels.map(&:title)
+  end
+
+  before_commit :apply_labels_list, unless: -> { labels_list.blank? }
+
+  def apply_labels_list
+    self.labels = @labels_list.map do |title|
+      project.issue_labels.with_title(title).first_or_create
+    end
+  end
 end

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -25,6 +25,19 @@
         <%= f.text_field :title, autofocus: true, class: "input-primary" %>
       </div>
 
+      <div class="mb-4 cpy-by-labels-titles flex flex-col items-stretch gap-2">
+        <%= f.label :labels_list, Issue.human_attribute_name(:label_ids), class: "label-primary" %>
+
+        <% available_options = (issue.labels_list + issue.project.issue_labels.map(&:title)).uniq.sort %>
+        <%= f.select :labels_list,
+            available_options,
+            { include_blank: false },
+            {
+              class: 'input-primary', multiple: true,
+              data: { controller: 'select2', tags: true }
+            } %>
+      </div>
+
       <%= render partial: 'issues/description_field', locals: { f:, issue: } %>
 
       <div class="flex gap-2 justify-center">

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -106,6 +106,9 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
   specify "I can add a new issue" do
     project = FactoryBot.create(:project)
+    project.issue_labels.create(title: "Development")
+    project.issue_labels.create(title: "Testing")
+    project.issue_labels.create(title: "Bug")
 
     visit project_issues_path(project)
 
@@ -114,14 +117,18 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     within '#new_issue_form' do
       fill_in 'issue_title', with: "My issue"
       write_in_md_editor_field("My description")
-      click_button 'Create'
     end
+
+    select_from_select2(selector: '.cpy-by-labels-titles .select2', option_text: "Development")
+
+    click_button 'Create'
 
     within 'table' do
       expect(page).to have_content("My issue")
     end
 
     expect(Issue.last.title).to eq("My issue")
+    expect(Issue.last.labels_list).to eq([ "Development" ])
     expect(Issue.last.description).to eq("My description")
   end
 

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+describe Issue do
+  let(:project) { create(:project) }
+  let(:issue) { create(:issue, project: project) }
+
+  describe 'labels_list implementation' do
+    context 'when given a comma-separated string' do
+      it 'sets the labels_list but not the labels' do
+        issue.labels_list = 'bug,feature,urgent'
+
+        expect(issue.labels_list).to eq([ 'bug', 'feature', 'urgent' ])
+        expect(issue.labels.count).to eq(0)
+        expect(issue.labels).to be_empty
+      end
+
+      it 'handles whitespace in the input' do
+        issue.labels_list = ' bug ,  feature , urgent '
+
+        expect(issue.labels_list).to match_array([ 'bug', 'feature', 'urgent' ])
+      end
+    end
+
+    context 'when given an array' do
+      it 'creates and assigns label list from array' do
+        issue.labels_list = [ 'bug', 'feature' ]
+
+        expect(issue.labels_list).to match_array([ 'bug', 'feature' ])
+      end
+    end
+
+    context 'when given blank input' do
+      it 'handles nil input' do
+        issue.labels_list = nil
+        expect(issue.labels).to be_empty
+      end
+
+      it 'handles empty string input' do
+        issue.labels_list = ''
+        expect(issue.labels).to be_empty
+        issue.labels_list = '    '
+        expect(issue.labels).to be_empty
+      end
+
+      it 'handles empty array input' do
+        issue.labels_list = []
+        expect(issue.labels).to be_empty
+      end
+    end
+
+    it "saves the @labels_list to the database creating or reusing labels" do
+      project.issue_labels.create!(title: "Bug")
+      expect(project.issue_labels.count).to eq(1)
+
+      issue.reload
+      issue.labels_list = 'bug,feature'
+      issue.save!
+
+      expect(project.issue_labels.count).to eq(2)
+      expect(issue.labels.count).to eq(2)
+      expect(issue.labels.pluck(:title)).to match_array([ 'Bug', 'feature' ])
+    end
+  end
+end


### PR DESCRIPTION
# Why
Previously, labels could only be added after an issue was created, requiring additional steps to properly categorize issues. This workflow improvement allows users to set labels during issue creation, making the process more efficient and encouraging better issue organization from the beginning.

# How
- Added a label picker field to the issue creation form
- Implemented labels_list method in the Issue model to handle label creation/assignment
- Labels can be input as comma-separated text or selected from existing labels

![image](https://github.com/user-attachments/assets/575ae4e9-f84d-4f65-ab27-a19eb2570cf3)
