### PR TITLE
chore: implements self hosted api client 

### DIFF
--- a/lib/app_version_updater.rb
+++ b/lib/app_version_updater.rb
@@ -21,22 +21,8 @@ class AppVersionUpdater
   end
 
   private def fetch_newest_version
-    return if Rails.env.development?
-    begin
-      uri = URI("https://eigenfocus.com/api/v1/app_versions/latest")
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == "https")
-
-      request = Net::HTTP::Get.new(uri)
-      request["App-Token"] = app_metadata.token
-      request["App-Version"] = app_metadata.current_version.to_s
-
-      response = http.request(request)
-      response = JSON.parse(response.body)
-      response["latest_version"]
-    rescue
-      ""
-    end
+    client = SelfHostedApiClient.new(app_metadata)
+    response = client.get("/app_versions/latest")
+    response&.fetch("latest_version", "")
   end
 end

--- a/lib/self_hosted_api_client.rb
+++ b/lib/self_hosted_api_client.rb
@@ -1,0 +1,28 @@
+require "net/http"
+require "uri"
+require "json"
+
+class SelfHostedApiClient
+  BASE_URL = "https://self-hosted-api-free.eigenfocus.com/v1"
+
+  def initialize(app_metadata)
+    @app_metadata = app_metadata
+  end
+
+  def get(path)
+    return {} if Rails.env.development?
+
+    uri = URI(BASE_URL.delete_suffix("/") + "/" + path.delete_prefix("/"))
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+
+    request = Net::HTTP::Get.new(uri)
+    request["App-Token"] = @app_metadata.token
+    request["App-Version"] = @app_metadata.current_version.to_s
+
+    response = http.request(request)
+    JSON.parse(response.body)
+  rescue
+    {}
+  end
+end


### PR DESCRIPTION
This PR implements a client class to the self hosted api. 

- Implementes `SelfHostedApiClient` with the new API endpoint
- Changes AppVersionUpdater to use the client