### PR TITLE
Feat: Change notification logic to allow for corrections

### DIFF
--- a/app/jobs/eigenfocus_notifications_fetcher_job.rb
+++ b/app/jobs/eigenfocus_notifications_fetcher_job.rb
@@ -3,9 +3,9 @@ class EigenfocusNotificationsFetcherJob < ApplicationJob
     lastest_news = EigenfocusNotificationsFetcher.call(AppMetadata.instance)
 
     lastest_news.each do |news|
-      next if Notification.exists?(external_id: news["id"])
+      notification = Notification.find_or_initialize_by(external_id: news["id"])
 
-      Notification.create!(
+      notification.update!(
         title: news["title"],
         content: news["content"],
         announcement_modes: news["announcement_modes"],

--- a/spec/jobs/eigenfocus_notifications_fetcher_job_spec.rb
+++ b/spec/jobs/eigenfocus_notifications_fetcher_job_spec.rb
@@ -52,7 +52,7 @@ describe EigenfocusNotificationsFetcherJob, type: :job do
 
     context 'when some notifications already exist' do
       before do
-        create(:notification, external_id: "news-1")
+        create(:notification, title: "Incorrect t1tl3", external_id: "news-1")
       end
 
       it 'only creates notifications for new items' do
@@ -64,6 +64,15 @@ describe EigenfocusNotificationsFetcherJob, type: :job do
         expect(new_notification).to have_attributes(
           external_id: "news-2",
           title: "System Maintenance"
+        )
+      end
+
+      it 'updates existing notifications' do
+        described_class.perform_now
+
+        previous_notification = Notification.find_by_external_id("news-1")
+        expect(previous_notification).to have_attributes(
+          title: "Important Update"
         )
       end
     end


### PR DESCRIPTION
## Why?

In case some notifications are published with typo or incorrect text, we want to update those for the users, instead of leaving incorrect.

This PR changes the Notification creation logic to perform an upsert instead of an  exclusive insert, which means that if an existing notification (identified by its external ID) already exists in the system, it is going to be updated instead of skipped