### PR TITLE
Chore/Refac: Improve consistency between visualizations/projects controllers

### DIFF
--- a/app/controllers/projects/base_controller.rb
+++ b/app/controllers/projects/base_controller.rb
@@ -1,0 +1,8 @@
+class Projects::BaseController < ApplicationController
+  helper_method :current_project
+
+  private
+  def current_project
+    @current_project ||= Project.find(params[:project_id])
+  end
+end

--- a/app/controllers/projects/issue_labels_controller.rb
+++ b/app/controllers/projects/issue_labels_controller.rb
@@ -1,6 +1,4 @@
-class Projects::IssueLabelsController < ApplicationController
-  helper_method :current_project
-
+class Projects::IssueLabelsController < Projects::BaseController
   def index
     @q = current_project.issue_labels.ransack(params[:q])
     @q.sorts = "updated_at desc" if @q.sorts.empty?
@@ -51,10 +49,6 @@ class Projects::IssueLabelsController < ApplicationController
   end
 
   private
-  def current_project
-    @current_project ||= Project.find(params[:project_id])
-  end
-
   def label_params
     params.require(:issue_label).permit(:title)
   end

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -1,7 +1,5 @@
-class Projects::IssuesController < ApplicationController
+class Projects::IssuesController < Projects::BaseController
   include IssueEmbeddable
-
-  helper_method :current_project
 
   def index
     @q = current_project.issues.ransack(params[:q])
@@ -68,10 +66,6 @@ class Projects::IssuesController < ApplicationController
   end
 
   private
-  def current_project
-    @current_project ||= Project.find(params[:project_id])
-  end
-
   def permitted_params
     params.require(:issue).permit(:title, :description, files: [], labels_list: [])
   end

--- a/app/controllers/visualizations/allocations_controller.rb
+++ b/app/controllers/visualizations/allocations_controller.rb
@@ -1,4 +1,4 @@
-class Visualizations::AllocationsController < ApplicationController
+class Visualizations::AllocationsController < Visualizations::BaseController
   def move
     @allocation = GroupingIssueAllocation.find_by(grouping_id: move_params[:from][:group], position: move_params[:from][:position])
     @allocation.update(grouping_id: move_params[:to][:group], position: move_params[:to][:position])

--- a/app/controllers/visualizations/base_controller.rb
+++ b/app/controllers/visualizations/base_controller.rb
@@ -1,0 +1,8 @@
+class Visualizations::BaseController < ApplicationController
+  helper_method :current_visualization
+
+  private
+  def current_visualization
+    @current_visualization ||= Visualization.find(params[:visualization_id])
+  end
+end

--- a/app/controllers/visualizations/groupings_controller.rb
+++ b/app/controllers/visualizations/groupings_controller.rb
@@ -1,6 +1,4 @@
-class Visualizations::GroupingsController < ApplicationController
-  helper_method :current_visualization
-
+class Visualizations::GroupingsController < Visualizations::BaseController
   def new
     @grouping = Grouping.new
 
@@ -55,10 +53,6 @@ class Visualizations::GroupingsController < ApplicationController
   end
 
   private
-  def current_visualization
-    @current_visualization ||= Visualization.find(params[:visualization_id])
-  end
-
   def permitted_params
     params.require(:grouping).permit(:title, :hidden)
   end

--- a/app/controllers/visualizations/issues_controller.rb
+++ b/app/controllers/visualizations/issues_controller.rb
@@ -1,6 +1,4 @@
-class Visualizations::IssuesController < ApplicationController
-  helper_method :current_visualization
-
+class Visualizations::IssuesController < Visualizations::BaseController
   def create
     @issue = Issue.new(permitted_params.merge(project_id: current_visualization.project.id))
     @grouping = Grouping.find params[:allocate_to_grouping_id]
@@ -18,10 +16,6 @@ class Visualizations::IssuesController < ApplicationController
   end
 
   private
-  def current_visualization
-    @current_visualization ||= Visualization.find(params[:visualization_id])
-  end
-
   def permitted_params
     params.require(:issue).permit(:title, :description, files: [])
   end

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -88,7 +88,7 @@
     data-controller="sortable"
     data-sortable-target="container"
     data-sortable-shared-group-value="cards"
-    data-sortable-move-path-value="<%= move_allocations_path %>"
+    data-sortable-move-path-value="<%= move_visualization_allocations_path(grouping.visualization) %>"
     data-sortable-grouping-id="<%= grouping.id %>"
     data-grouping-column-target="cardContainer"
     >

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,9 @@ Rails.application.routes.draw do
       end
 
       resources :issues, path: "i", only: [ :create, :update, :destroy ]
+      resources :allocations, only: [] do
+        post :move, on: :collection
+      end
     end
   end
 
@@ -70,12 +73,6 @@ Rails.application.routes.draw do
           as: :show_issue,
           controller: :issues,
           action: :index
-    end
-  end
-
-  scope module: :visualizations do
-    resources :allocations, only: [] do
-      post :move, on: :collection
     end
   end
 


### PR DESCRIPTION
## Why?

This refactory is just to make our code base more consistency, by adding a BaseController on the visualizations and projects scope, so that shared methods are reused instead of copy/pasted.

No change in behavior is expected after merging this PR

## How

- Move allocations controller as a nested resource for visualizations
- Create base controller for visualizations
- Create base controller for projects