### PR TITLE
chore: keep entity listed when opening 'new/edit' modal forms in new browser tab

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,4 +65,8 @@ class ApplicationController < ActionController::Base
     flash_type ||= :notice
     t("flash.actions.#{action_name}.#{flash_type}", resource_name: resource.model_name.human)
   end
+
+  def turbo_frame_request?
+    request.headers["Turbo-Frame"]
+  end
 end

--- a/app/controllers/projects/issue_labels_controller.rb
+++ b/app/controllers/projects/issue_labels_controller.rb
@@ -8,7 +8,12 @@ class Projects::IssueLabelsController < Projects::BaseController
 
   def new
     @issue_label = current_project.issue_labels.new
-    render partial: "form", locals: { project: current_project, issue_label: @issue_label }
+
+    if turbo_frame_request?
+      render partial: "form", locals: { project: current_project, issue_label: @issue_label }
+    else
+      redirect_to project_issue_labels_path(current_project, open_form: true)
+    end
   end
 
   def create
@@ -27,7 +32,11 @@ class Projects::IssueLabelsController < Projects::BaseController
   def edit
     @issue_label = current_project.issue_labels.find(params[:id])
 
-    render partial: "form", locals: { project: current_project, issue_label: @issue_label }
+    if turbo_frame_request?
+      render partial: "form", locals: { project: current_project, issue_label: @issue_label }
+    else
+      redirect_to project_issue_labels_path(current_project, open_form: true, form_issue_label_id: @issue_label.id)
+    end
   end
 
   def update

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -19,6 +19,10 @@ class Projects::IssuesController < Projects::BaseController
 
   def new
     @issue = current_project.issues.new
+
+    unless turbo_frame_request?
+      redirect_to project_issues_path(current_project, open_form: true)
+    end
   end
 
   def create

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -5,7 +5,12 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
-    render partial: "form", locals: { project: @project  }
+
+    if turbo_frame_request?
+      render partial: "form", locals: { project: @project }
+    else
+      redirect_to projects_path(open_form: true)
+    end
   end
 
   def create
@@ -18,7 +23,12 @@ class ProjectsController < ApplicationController
 
   def edit
     @project = Project.find(params[:id])
-    render partial: "form", locals: { project: @project }
+
+    if turbo_frame_request?
+      render partial: "form", locals: { project: @project }
+    else
+      redirect_to projects_path(open_form: true, form_project_id: @project.id)
+    end
   end
 
   def update

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -17,7 +17,12 @@ class TimeEntriesController < ApplicationController
 
   def new
     @time_entry = current_user.time_entries.new(reference_date: params[:reference_date])
-    render partial: "form", locals: { time_entry: @time_entry }
+
+    if turbo_frame_request?
+      render partial: "form", locals: { time_entry: @time_entry }
+    else
+      redirect_to time_entries_path(new_entry: { reference_date: params[:reference_date] })
+    end
   end
 
   def form_projects_dependent_fields

--- a/app/controllers/time_entries_controller.rb
+++ b/app/controllers/time_entries_controller.rb
@@ -47,7 +47,11 @@ class TimeEntriesController < ApplicationController
   def edit
     @time_entry = current_user.time_entries.find(params[:id])
 
-    render partial: "form", locals: { time_entry: @time_entry }
+    if turbo_frame_request?
+      render partial: "form", locals: { time_entry: @time_entry }
+    else
+      redirect_to time_entries_path(time_entry_id: params[:id])
+    end
   end
 
   def update

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -15,7 +15,7 @@
       data: { turbo_frame: 'project_form' } %>
 </div>
 
-<%= turbo_frame_tag 'project_form' do %>
+<%= turbo_frame_tag 'project_form', src: (params[:open_form] ? params[:form_project_id] ? edit_project_path(params[:form_project_id]) : new_project_path : nil) do %>
 <% end %>
 
 <%= turbo_frame_tag 'projects', class: "tour--projects-list" do %>

--- a/app/views/projects/issue_labels/index.html.erb
+++ b/app/views/projects/issue_labels/index.html.erb
@@ -1,6 +1,6 @@
 <% set_page_title(:project_all_issues_labels, project_name: current_project.name) %>
 
-<%= turbo_frame_tag 'issue_label_form' do %>
+<%= turbo_frame_tag 'issue_label_form', src: (params[:open_form] ? params[:form_issue_label_id] ? edit_project_issue_label_path(current_project, params[:form_issue_label_id]) : new_project_issue_label_path(current_project) : nil) do %>
 <% end %>
 
 <%= turbo_frame_tag 'issue_label_removal_confirmation' do %>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -2,7 +2,7 @@
 
 <%= start_pending_app_tour_tag("issues/index") %>
 
-<%= turbo_frame_tag 'new_issue_form' do %>
+<%= turbo_frame_tag 'new_issue_form', src: (params[:open_form] ? new_project_issue_path(current_project) : nil) do %>
 <% end %>
 
 <%= render partial: 'projects/navigation_header', locals: {

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -11,6 +11,8 @@
   %>
 
   <%= render partial: 'form', locals: { time_entry: new_entry } %>
+<% elsif params[:time_entry_id].present? %>
+  <%= render partial: 'form', locals: { time_entry: TimeEntry.find(params[:time_entry_id]) } %>
 <% else %>
   <%= start_pending_app_tour_tag("time_entries/index") %>
 

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -5,8 +5,8 @@
 <% if params[:new_entry].present? %>
   <%
     new_entry = TimeEntry.new
-    new_entry.project = Project.find(params[:new_entry][:project_id])
-    new_entry.issue = new_entry.project.issues.find_by_id(params[:new_entry][:issue_id])
+    new_entry.project = Project.find(params[:new_entry][:project_id]) if params[:new_entry][:project_id].present?
+    new_entry.issue = new_entry.project.issues.find_by_id(params[:new_entry][:issue_id]) if params[:new_entry][:issue_id].present?
     new_entry.reference_date = @reference_date
   %>
 


### PR DESCRIPTION
This PR implements a way for using the 'new/edit' buttons in new browser tabs. This was implemented for:

- Time entries
- All Issues
- Issue Labels
- Projects