### PR TITLE
Chore: Refactory dispatch event to send json in a script tag

### DIFF
--- a/app/javascript/initializers/turbo_stream/dispatch_event.js
+++ b/app/javascript/initializers/turbo_stream/dispatch_event.js
@@ -15,9 +15,10 @@ StreamActions.dispatch_event = function() {
   const eventName = this.getAttribute("event")
 
   let data = {}
-  const rawData = this.getAttribute("data")
 
-  if (rawData) {
+  if (this.templateContent && this.templateContent.querySelector("script")) {
+    const rawData = this.templateContent.querySelector("script").innerText
+
     try {
       data = JSON.parse(rawData)
     } catch (error) {

--- a/config/initializers/turbo_stream.rb
+++ b/config/initializers/turbo_stream.rb
@@ -6,7 +6,7 @@ module TurboStreamDispatchEventHelper
     # Allows data to be serialized before dispatching it
     data = data.to_json unless data.is_a? String
 
-    template = content_tag :script, data.to_s.html_safe, type: "application/json"
+    template = content_tag :script, data.html_safe, type: "application/json"
 
     turbo_stream_action_tag :dispatch_event, event: event, template: template
   end

--- a/config/initializers/turbo_stream.rb
+++ b/config/initializers/turbo_stream.rb
@@ -6,7 +6,9 @@ module TurboStreamDispatchEventHelper
     # Allows data to be serialized before dispatching it
     data = data.to_json unless data.is_a? String
 
-    turbo_stream_action_tag :dispatch_event, event: event, data: data
+    template = content_tag :script, data.to_s.html_safe, type: "application/json"
+
+    turbo_stream_action_tag :dispatch_event, event: event, template: template
   end
 end
 


### PR DESCRIPTION
## Why?

To make debugging easier, we are changing the dispatch event turbo stream tag to use a script tag with the JSON inside it.