### PR TITLE
Archive/Unarchive/Remove feature for Projects and Issues

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -12,6 +12,16 @@ class IssuesController < ApplicationController
     end
   end
 
+  def archive
+    @issue = Issue.find(params[:id])
+    @issue.archive!
+  end
+
+  def unarchive
+    @issue = Issue.find(params[:id])
+    @issue.unarchive!
+  end
+
   def destroy
     @issue = Issue.find(params[:id])
     @issue.destroy

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -4,6 +4,7 @@ class Projects::IssuesController < Projects::BaseController
   def index
     @q = current_project.issues.ransack(params[:q])
     @q.sorts = "updated_at desc" if @q.sorts.empty?
+    @q.by_archiving_status ||= "active"
 
     @pagy, @issues = pagy(@q.result.includes(:labels, :groupings))
 

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -69,6 +69,16 @@ class Projects::IssuesController < Projects::BaseController
     head :ok
   end
 
+  def archive
+    @issue = Issue.find(params[:id])
+    @issue.archive!
+  end
+
+  def unarchive
+    @issue = Issue.find(params[:id])
+    @issue.unarchive!
+  end
+
   private
   def permitted_params
     params.require(:issue).permit(:title, :description, files: [], labels_list: [])

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -69,16 +69,6 @@ class Projects::IssuesController < Projects::BaseController
     head :ok
   end
 
-  def archive
-    @issue = Issue.find(params[:id])
-    @issue.archive!
-  end
-
-  def unarchive
-    @issue = Issue.find(params[:id])
-    @issue.unarchive!
-  end
-
   private
   def permitted_params
     params.require(:issue).permit(:title, :description, files: [], labels_list: [])

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -53,6 +53,18 @@ class ProjectsController < ApplicationController
     @project.unarchive!
   end
 
+  def destroy
+    @project = Project.find(params[:id])
+
+    if @project.destroy
+      flash[:success] = t_flash_message(@project)
+    else
+      flash[:error] = @project.errors.full_messages.to_sentence
+    end
+
+    redirect_to projects_path
+  end
+
   private
 
   def project_params

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -14,7 +14,19 @@ class Issue < ApplicationRecord
   validates :title, presence: true
 
   # Scopes
-  scope :active, -> { where(archived_at: nil) }
+  scope :archived, ->(archived = true) { archived ? where.not(archived_at: nil) : where(archived_at: nil) }
+  scope :active, -> { archived(false) }
+  scope :by_archiving_status, ->(status) {
+    case status
+    when "all"
+      all
+    when "active"
+      active
+    when "archived"
+      archived(true)
+    end
+  }
+
   scope :by_label_titles, ->(*label_titles) do
     # This scope is using splat operator because ransack has a buggy behavior
     # for array values with scopes.
@@ -58,7 +70,7 @@ class Issue < ApplicationRecord
   end
 
   def self.ransackable_scopes(auth_object = nil)
-    [ "by_label_titles" ]
+    [ "by_label_titles", "by_archiving_status" ]
   end
 
   # Broadcasts

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -14,6 +14,7 @@ class Issue < ApplicationRecord
   validates :title, presence: true
 
   # Scopes
+  scope :active, -> { where(archived_at: nil) }
   scope :by_label_titles, ->(*label_titles) do
     # This scope is using splat operator because ransack has a buggy behavior
     # for array values with scopes.

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -106,7 +106,7 @@ class Issue < ApplicationRecord
 
   private def ensure_is_archived
     unless archived?
-      errors.add(:base, I18n.t("activerecord.errors.project.destroy.not_archived"))
+      errors.add(:base, :must_be_archived_to_destroy)
       throw(:abort)
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,6 +11,7 @@ class Project < ApplicationRecord
   # Validations
   validates :name, presence: true
   validates :use_template, inclusion: { in: Project::Templatable::Template::AVAILABLE_TEMPLATES }, on: :create, if: -> { use_template.present? }
+  before_destroy :ensure_is_archived
 
   # Hookes
   after_create :apply_template, if: -> { use_template.present? }
@@ -36,5 +37,9 @@ class Project < ApplicationRecord
   private def apply_template
     template = Project::Templatable::Template.find(use_template)
     Project::Templatable::TemplateApplier.new(self, template).apply
+  end
+
+  private def ensure_is_archived
+    throw(:abort) unless archived?
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -40,6 +40,9 @@ class Project < ApplicationRecord
   end
 
   private def ensure_is_archived
-    throw(:abort) unless archived?
+    unless archived?
+      errors.add(:base, I18n.t("activerecord.errors.project.destroy.not_archived"))
+      throw(:abort)
+    end
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,7 +41,7 @@ class Project < ApplicationRecord
 
   private def ensure_is_archived
     unless archived?
-      errors.add(:base, I18n.t("activerecord.errors.project.destroy.not_archived"))
+      errors.add(:base, :must_be_archived_to_destroy)
       throw(:abort)
     end
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -13,7 +13,10 @@ class Project < ApplicationRecord
   validates :use_template, inclusion: { in: Project::Templatable::Template::AVAILABLE_TEMPLATES }, on: :create, if: -> { use_template.present? }
   before_destroy :ensure_is_archived
 
-  # Hookes
+  # Scopes
+  scope :active, -> { where(archived_at: nil) }
+
+  # Hooks
   after_create :apply_template, if: -> { use_template.present? }
 
   def default_visualization

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -97,9 +97,11 @@
               <%= render partial: 'issues/issue_detail/grouping_picker', locals: { issue: issue } %>
             <% end %>
 
-            <%= link_to time_entries_path(new_entry: { project_id: issue.project_id, issue_id: issue.id }), class: "mt-8 btn-outline-primary text-nowrap flex gap-2 items-center py-2 tour--issue-detail-time-tracking", data: { turbo_frame: "_top" } do %>
-              <%= icon_for(:time_entries) %>
-              <span class="sm:block"><%= t("actions.start_time_tracking") %></span>
+            <% unless issue.archived? %>
+              <%= link_to time_entries_path(new_entry: { project_id: issue.project_id, issue_id: issue.id }), class: "mt-8 btn-outline-primary text-nowrap flex gap-2 items-center py-2 tour--issue-detail-time-tracking", data: { turbo_frame: "_top" } do %>
+                <%= icon_for(:time_entries) %>
+                <span class="sm:block"><%= t("actions.start_time_tracking") %></span>
+              <% end %>
             <% end %>
 
             <div class="mt-4 flex flex-col gap-2 items-stretch">

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -24,6 +24,11 @@
           <h4 class="text-lg font-medium text-readable-content-700">
             <%= issue.persisted? ? "#{t("actions.edit")} #{Issue.model_name.human}" : "#{t("actions.create")} #{Issue.model_name.human}"%>
           </h4>
+          <% if issue.archived? %>
+            <span class="inline-block rounded-full border-warning-600 bg-warning-200 text-warning-800 border py-1 px-3 text-xs font-medium text-warning-600">
+              <%= t('archived').capitalize %>
+            </span>
+          <% end %>
         </div>
       </div>
       <div class="flex flex-col md:flex-row gap-8">
@@ -101,7 +106,7 @@
               <h5 class="w-full mb-2"><%= t("menu.actions") %></h5>
               <% if issue.archived? %>
                   <%= link_to t('actions.unarchive'),
-                  unarchive_project_issue_path(issue.project, issue),
+                  unarchive_issue_path(issue),
                   class: "btn-success",
                   data: { turbo_method: :put, turbo_confirm: t("confirmations.unarchive") }
                   %>
@@ -111,8 +116,8 @@
                 <% end %>
               <% else %>
                 <%= link_to t('actions.archive'),
-                    archive_project_issue_path(issue.project, issue),
-                    class: "btn-danger",
+                    archive_issue_path(issue),
+                    class: "btn-cancel",
                     data: { turbo_method: :put, turbo_confirm: t("confirmations.archive") }
                     %>
               <% end %>

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -110,7 +110,7 @@
                   class: "btn-success",
                   data: { turbo_method: :put, turbo_confirm: t("confirmations.unarchive") }
                   %>
-                <%= link_to destroy_path, class: "btn-danger flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
+                <%= link_to destroy_path, class: "btn-danger flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.confirm_destroy", resource_name: Issue.model_name.human.downcase) } do %>
                   <i class="fa-solid fa-trash"></i>
                   <%= t("actions.remove") %>
                 <% end %>
@@ -118,7 +118,7 @@
                 <%= link_to t('actions.archive'),
                     archive_issue_path(issue),
                     class: "btn-cancel",
-                    data: { turbo_method: :put, turbo_confirm: t("confirmations.archive") }
+                    data: { turbo_method: :put, turbo_confirm: t("issue.confirm_archive") }
                     %>
               <% end %>
             </div>

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -97,11 +97,24 @@
               <span class="sm:block"><%= t("actions.start_time_tracking") %></span>
             <% end %>
 
-            <div class="mt-4 flex flex-col items-stretch">
+            <div class="mt-4 flex flex-col gap-2 items-stretch">
               <h5 class="w-full mb-2"><%= t("menu.actions") %></h5>
-              <%= link_to destroy_path, class: "btn-danger flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
-                <i class="fa-solid fa-trash"></i>
-                <%= t("actions.remove") %>
+              <% if issue.archived? %>
+                  <%= link_to t('actions.unarchive'),
+                  unarchive_project_issue_path(issue.project, issue),
+                  class: "btn-success",
+                  data: { turbo_method: :put, turbo_confirm: t("confirmations.unarchive") }
+                  %>
+                <%= link_to destroy_path, class: "btn-danger flex items-center gap-2", data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation", resource_name: Issue.model_name.human.downcase) } do %>
+                  <i class="fa-solid fa-trash"></i>
+                  <%= t("actions.remove") %>
+                <% end %>
+              <% else %>
+                <%= link_to t('actions.archive'),
+                    archive_project_issue_path(issue.project, issue),
+                    class: "btn-danger",
+                    data: { turbo_method: :put, turbo_confirm: t("confirmations.archive") }
+                    %>
               <% end %>
             </div>
           </div>

--- a/app/views/issues/archive.turbo_stream.erb
+++ b/app/views/issues/archive.turbo_stream.erb
@@ -1,3 +1,4 @@
-<%= turbo_stream.remove dom_id(@issue) %>
+<%= turbo_stream.remove_all "[data-grouping-column-issue-id-value='#{@issue.id}']" %>
 <%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
+<%= turbo_stream.replace_all "#all-issues-list #issue_#{@issue.id}", partial: "projects/issues/issue", locals: { issue: @issue } %>
 <%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/issues/archive.turbo_stream.erb
+++ b/app/views/issues/archive.turbo_stream.erb
@@ -1,3 +1,3 @@
-<%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue, project: current_project } %>
+<%= turbo_stream.remove dom_id(@issue) %>
 <%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
 <%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/issues/unarchive.turbo_stream.erb
+++ b/app/views/issues/unarchive.turbo_stream.erb
@@ -4,5 +4,6 @@
     issue: @issue
   } %>
 <% end %>
+<%= turbo_stream.replace_all "#all-issues-list #issue_#{@issue.id}", partial: "projects/issues/issue", locals: { issue: @issue } %>
 <%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
 <%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/issues/unarchive.turbo_stream.erb
+++ b/app/views/issues/unarchive.turbo_stream.erb
@@ -1,0 +1,8 @@
+<% if allocated_grouping = @issue.groupings.first %>
+  <%= turbo_stream.append "#{ allocated_grouping.id }-cards-wrapper", partial: "visualizations/card", locals: {
+    visualization: @issue.project.default_visualization,
+    issue: @issue
+  } %>
+<% end %>
+<%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
+<%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -22,20 +22,20 @@
       <% if project.archived? %>
         <%= link_to t('actions.unarchive'),
                     unarchive_project_path(project),
-                    class: "btn-success",
+                    class: "btn-cancel",
                     data: { turbo_method: :put, turbo_confirm: t("confirmations.unarchive") }
                     %>
 
         <%= link_to t('actions.remove'),
                     project_path(project),
                     class: "btn-danger",
-                    data: { turbo_method: :delete, turbo_confirm: t(".confirmations_remove"), turbo_frame: "_top" }
+                    data: { turbo_method: :delete, turbo_confirm: t(".confirm_destroy"), turbo_frame: "_top" }
                     %>
       <% else %>
         <%= link_to t('actions.archive'),
                     archive_project_path(project),
-                    class: "btn-danger",
-                    data: { turbo_method: :put, turbo_confirm: t("confirmations.archive") }
+                    class: "btn-cancel",
+                    data: { turbo_method: :put, turbo_confirm: t(".confirm_archive") }
                     %>
       <% end  %>
 

--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -25,6 +25,12 @@
                     class: "btn-success",
                     data: { turbo_method: :put, turbo_confirm: t("confirmations.unarchive") }
                     %>
+
+        <%= link_to t('actions.remove'),
+                    project_path(project),
+                    class: "btn-danger",
+                    data: { turbo_method: :delete, turbo_confirm: t(".confirmations_remove"), turbo_frame: "_top" }
+                    %>
       <% else %>
         <%= link_to t('actions.archive'),
                     archive_project_path(project),

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,11 +1,20 @@
-<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "cpy-filter-form" do |f| %>
+<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "cpy-filter-form", data: { controller: 'form' } do |f| %>
   <div class="flex flex-col md:flex-row justify-between items-stretch gap-4">
     <div class="flex flex-col md:flex-row justify-start items-stretch gap-4">
+      <div class="flex gap-2 grow items-center cpy-by-status">
+        <%= f.select :by_archiving_status, ['all', 'active', 'archived'].map { |status| [t(".by_archiving_status.#{status}"), status] },
+          { include_hidden: false },
+          class: 'input-primary input-sm',
+          data: {
+            action: 'change->form#submit'
+          }
+        %>
+      </div>
+
       <div class="flex gap-2 md:w-60 items-center">
         <%= f.label :title_cont, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
         <%= f.search_field :title_cont, class: 'input-contrast input-sm' %>
       </div>
-
 
       <div class="flex gap-2 md:grow md:w-72 items-center cpy-by-labels-titles">
         <%= f.label :by_label_titles, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -4,7 +4,7 @@
       <div class="flex gap-2 grow items-center cpy-by-status">
         <%= f.select :by_archiving_status, ['all', 'active', 'archived'].map { |status| [t(".by_archiving_status.#{status}"), status] },
           { include_hidden: false },
-          class: 'input-primary input-sm',
+          class: 'input-primary input-sm pr-8',
           data: {
             action: 'change->form#submit'
           }

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -1,5 +1,12 @@
 <tr id="<%= dom_id(issue) %>">
-  <td><%= issue.title %></td>
+  <td>
+    <%= issue.title %>
+    <% if issue.archived? %>
+      <span class="ml-2 inline-block rounded-full border-warning-600 bg-warning-200 text-warning-800 border py-1 px-3 text-xs font-medium text-warning-600">
+        <%= t('archived').capitalize %>
+      </span>
+    <% end %>
+  </td>
   <td>
     <%= labels_list_for(issue) %>
   </td>
@@ -14,7 +21,7 @@
   <td><%= l issue.updated_at, format: :short %></td>
   <td class="tour--issue-actions">
     <div class="flex gap-4 text-lg opacity-80">
-      <%= link_to project_show_issue_path(project, issue),
+      <%= link_to project_show_issue_path(issue.project, issue),
           class: "link-primary text-sm cpy-edit-button",
           data: { turbo_frame: 'issue_detail', turbo_action: 'advance' } do %>
         <i class="fa-solid fa-up-right-from-square mr-1"></i>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -15,15 +15,10 @@
   <td class="tour--issue-actions">
     <div class="flex gap-4 text-lg opacity-80">
       <%= link_to project_show_issue_path(project, issue),
-          class: "link-base cpy-edit-button",
+          class: "link-primary text-sm cpy-edit-button",
           data: { turbo_frame: 'issue_detail', turbo_action: 'advance' } do %>
-        <i class="fa fa-edit"></i>
-      <% end %>
-
-      <%= link_to issue_path(issue),
-          class: "link-danger cpy-delete-button",
-          data: { turbo_method: :delete, turbo_confirm: t("issue.destroy_confirmation") } do %>
-        <i class="fa fa-trash-can"></i>
+        <i class="fa-solid fa-up-right-from-square mr-1"></i>
+        <%= t("actions.go_to_issue") %>
       <% end %>
     </div>
   </td>

--- a/app/views/projects/issues/archive.turbo_stream.erb
+++ b/app/views/projects/issues/archive.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue, project: current_project } %>
+<%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
+<%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/projects/issues/unarchive.turbo_stream.erb
+++ b/app/views/projects/issues/unarchive.turbo_stream.erb
@@ -1,3 +1,0 @@
-<%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue, project: current_project } %>
-<%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
-<%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/projects/issues/unarchive.turbo_stream.erb
+++ b/app/views/projects/issues/unarchive.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue, project: current_project } %>
+<%= turbo_stream.replace 'issue_detail', partial: 'issues/issue_detail', locals: { issue: @issue, destroy_path: issue_path(@issue) } %>
+<%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>

--- a/app/views/projects/issues/update.turbo_stream.erb
+++ b/app/views/projects/issues/update.turbo_stream.erb
@@ -1,5 +1,5 @@
 <% if @issue.persisted? %>
-  <%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue, project: current_project } %>
+  <%= turbo_stream.replace dom_id(@issue), partial: "projects/issues/issue", locals: { issue: @issue } %>
   <%= new_turbo_stream_alert_message(:success, t_flash_message(@issue)) %>
 <% else %>
   <%= new_turbo_stream_alert_message(:error, @issue.errors.full_messages.to_sentence) %>

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -32,7 +32,7 @@
       <div class="flex gap-2 flex-col cpy-project-list tour--project-selection">
         <%= f.label :project_id, TimeEntry.human_attribute_name(:project), autofocus: (time_entry.new_record? && time_entry.project_id.blank?), class: "label-primary" %>
         <%
-          projects_for_select = Project.active.order(name: :asc)
+          projects_for_select = Project.active.order(name: :asc).to_a
 
           if time_entry.persisted? and time_entry.project.archived?
             projects_for_select.push(time_entry.project)

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -31,8 +31,14 @@
 
       <div class="flex gap-2 flex-col cpy-project-list tour--project-selection">
         <%= f.label :project_id, TimeEntry.human_attribute_name(:project), autofocus: (time_entry.new_record? && time_entry.project_id.blank?), class: "label-primary" %>
+        <%
+          projects_for_select = Project.active.order(name: :asc)
 
-        <%= f.select :project_id, options_from_collection_for_select(Project.order(name: :asc).all, :id, :name, time_entry.project_id), { include_blank: t('select_one') }, {required: true, style: "width: 100%", data: {
+          if time_entry.persisted? and time_entry.project.archived?
+            projects_for_select.push(time_entry.project)
+          end
+        %>
+        <%= f.select :project_id, options_from_collection_for_select(projects_for_select, :id, :name, time_entry.project_id), { include_blank: t('select_one') }, {required: true, style: "width: 100%", data: {
           controller: 'select2',
           dependent_fields_target: "hasDependents",
           dependant_turbo_frame_selector: '#project_dependent_fields'

--- a/app/views/time_entries/_form_project_dependent_fields.html.erb
+++ b/app/views/time_entries/_form_project_dependent_fields.html.erb
@@ -36,9 +36,15 @@
 
     <% if time_entry.project.present? %>
       <% if time_entry.project.issues.any? %>
-        <% issues = time_entry.project_id.present? ? time_entry.project.issues.order(title: :asc) : [] %>
+        <%
+          issues_for_select = time_entry.project.issues.active.order(title: :asc)
+
+          if time_entry.persisted? and time_entry.issue.archived?
+            issues_for_select.push(time_entry.issue)
+          end
+        %>
         <%= select_tag "time_entry[issue_id]",
-            options_from_collection_for_select(issues, :id, :title, time_entry.issue_id),
+            options_from_collection_for_select(issues_for_select, :id, :title, time_entry.issue_id),
             {
               include_blank: t('none_selected_f'),
               style: "width: 100%",

--- a/app/views/time_entries/_form_project_dependent_fields.html.erb
+++ b/app/views/time_entries/_form_project_dependent_fields.html.erb
@@ -37,7 +37,7 @@
     <% if time_entry.project.present? %>
       <% if time_entry.project.issues.any? %>
         <%
-          issues_for_select = time_entry.project.issues.active.order(title: :asc)
+          issues_for_select = time_entry.project.issues.active.order(title: :asc).to_a
 
           if time_entry.persisted? and time_entry.issue.archived?
             issues_for_select.push(time_entry.issue)

--- a/app/views/time_entries/_time_entry.html.erb
+++ b/app/views/time_entries/_time_entry.html.erb
@@ -89,7 +89,7 @@
       data: {
         turbo_frame: "time_entry_form",
         turbo_method: :delete,
-        turbo_confirm: t(".confirm_remove")
+        turbo_confirm: t(".confirm_destroy")
 
       }  do %>
 

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -94,7 +94,7 @@
     >
 
     <% unless grouping.hidden %>
-      <% grouping.issues.each do |issue| %>
+      <% grouping.issues.active.each do |issue| %>
         <%= render partial: 'visualizations/card', locals: {
           issue:,
           visualization: ,

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -1,6 +1,7 @@
 en:
   issue:
-    destroy_confirmation: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
+    confirm_destroy: "After the removal, all time entries linked to this issue wil be unlinked. Do you want to proceed?"
+    confirm_archive: "Are you sure you want to archive this issue? This will prevent it from being used in any time tracking activities. The existing time entries will not be affected."
   projects:
     form:
       select_template: "Select a project template"
@@ -9,7 +10,8 @@ en:
     project:
       enable_time_tracking: 'Enable time tracking'
       disable_time_tracking: 'Disable time tracking'
-      confirmations_remove: "Are you sure you want to remove this project? This will delete all the data associated with it such as issues, time entries, etc. And it can't be undone."
+      confirm_archive: "Are you sure you want to archive this project? This will prevent it from being used in any time tracking or project management activities. The existing issues and time entries will not be affected."
+      confirm_destroy: "Are you sure you want to remove this project? This will delete all the data associated with it such as issues, time entries, etc. And it can't be undone."
     issue_labels:
       destroy_confirmation:
         explanation: "Deleting this label will remove all of its associations with issues, but will not remove the issues."
@@ -106,7 +108,7 @@ en:
       success: 'Time entry logging stopped.'
     time_entry:
       no_description: "no description"
-      confirm_remove: "Do you want to remove this time entry? This action can not be undone."
+      confirm_destroy: "Do you want to remove this time entry? This action can not be undone."
   reports:
     total_time:
       report:

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -9,6 +9,7 @@ en:
     project:
       enable_time_tracking: 'Enable time tracking'
       disable_time_tracking: 'Disable time tracking'
+      confirmations_remove: "Are you sure you want to remove this project? This will delete all the data associated with it such as issues, time entries, etc. And it can't be undone."
     issue_labels:
       destroy_confirmation:
         explanation: "Deleting this label will remove all of its associations with issues, but will not remove the issues."

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -17,6 +17,11 @@ en:
         explanation: "Deleting this label will remove all of its associations with issues, but will not remove the issues."
         associations: "This label is associated with %{count_text}"
     issues:
+      filter:
+        by_archiving_status:
+          all: "List all issues"
+          active: "List only active issues"
+          archived: "List only archived issues"
       issue:
         no_grouping: "No column"
   survey_responses:

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -9,6 +9,7 @@ pt-BR:
     project:
       enable_time_tracking: 'Habilitar registro de tempo'
       disable_time_tracking: 'Desabilitar registro de tempo'
+      confirmations_remove: "Tem certeza que deseja remover este projeto? Isso deletará todos os dados associados a ele como issues e registros de tempo. Esta operação não pode ser desfeita."
     issue_labels:
       destroy_confirmation:
         explanation: "Deletar essa label removerá todas as suas associações com issues, mas não removerá as issues."

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -1,6 +1,7 @@
 pt-BR:
   issue:
-    destroy_confirmation: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
+    confirm_destroy: "Ao remover esta issue, todas os registros de tempo vinculados a ela serão desvinculados. Deseja prosseguir?"
+    confirm_archive: "Tem certeza que deseja arquivar esta issue? Isso impedirá que ela seja utilizada em atividades de registro de tempo. Os registros de tempo existentes não serão afetados."
   projects:
     form:
       select_template: "Selecione um template de projeto"
@@ -9,7 +10,8 @@ pt-BR:
     project:
       enable_time_tracking: 'Habilitar registro de tempo'
       disable_time_tracking: 'Desabilitar registro de tempo'
-      confirmations_remove: "Tem certeza que deseja remover este projeto? Isso deletará todos os dados associados a ele como issues e registros de tempo. Esta operação não pode ser desfeita."
+      confirm_archive: "Tem certeza que deseja arquivar este projeto? Isso impedirá que ele seja utilizado em atividades de registro de tempo ou gerenciamento. As issues ou registros de tempo existentes não serão afetados."
+      confirm_destroy: "Tem certeza que deseja remover este projeto? Isso deletará todos os dados associados a ele como issues e registros de tempo. Esta operação não pode ser desfeita."
     issue_labels:
       destroy_confirmation:
         explanation: "Deletar essa label removerá todas as suas associações com issues, mas não removerá as issues."
@@ -108,7 +110,7 @@ pt-BR:
         success: 'Marcação de tempo parada com sucesso.'
     time_entry:
       no_description: "sem descrição"
-      confirm_remove: "Deseja realmente remover este registro de tempo? Esta ação não poderá ser desfeita."
+      confirm_destroy: "Deseja realmente remover este registro de tempo? Esta ação não poderá ser desfeita."
   reports:
     total_time:
       report:

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -87,6 +87,11 @@ pt-BR:
         title: "DICA RÁPIDA"
         description: "Passe o mouse sobre um card e pressione de 1 a 6 no teclado para aplicar/remover uma label."
   issues:
+    filter:
+      by_archiving_status:
+        all: "Listar todas as issues"
+        active: "Listar issues ativas"
+        archived: "Listar issues arquivadas"
     issue_detail:
       grouping_picker:
         in_grouping: "Na coluna"

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -67,3 +67,7 @@ en:
 
       visualization:
         favorite_issue_labels: "Favorite labels"
+    errors:
+      project:
+        destroy:
+          not_archived: "Project must be archived before it can be removed."

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -68,9 +68,8 @@ en:
       visualization:
         favorite_issue_labels: "Favorite labels"
     errors:
-      project:
-        destroy:
-          not_archived: "Project must be archived before it can be removed."
-      issue:
-        destroy:
-          not_archived: "Issue must be archived before it can be removed."
+      models:
+        project:
+          must_be_archived_to_destroy: "Project must be archived before it can be removed."
+        issue:
+          must_be_archived_to_destroy: "Issue must be archived before it can be removed."

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -71,3 +71,6 @@ en:
       project:
         destroy:
           not_archived: "Project must be archived before it can be removed."
+      issue:
+        destroy:
+          not_archived: "Issue must be archived before it can be removed."

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -71,3 +71,6 @@ pt-BR:
       project:
         destroy:
           not_archived: "Um projeto deve estar arquivado antes de ser removido."
+      issue:
+        destroy:
+          not_archived: "Uma issue deve estar arquivada antes de ser removida."

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -68,9 +68,10 @@ pt-BR:
       visualization:
         favorite_issue_labels: "Labels favoritas"
     errors:
-      project:
-        destroy:
-          not_archived: "Um projeto deve estar arquivado antes de ser removido."
-      issue:
-        destroy:
-          not_archived: "Uma issue deve estar arquivada antes de ser removida."
+      models:
+        project:
+          destroy:
+            must_be_archived_to_destroy: "Um projeto deve estar arquivado antes de ser removido."
+        issue:
+          destroy:
+            must_be_archived_to_destroy: "Uma issue deve estar arquivada antes de ser removida."

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -67,3 +67,7 @@ pt-BR:
 
       visualization:
         favorite_issue_labels: "Labels favoritas"
+    errors:
+      project:
+        destroy:
+          not_archived: "Um projeto deve estar arquivado antes de ser removido."

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -70,8 +70,6 @@ pt-BR:
     errors:
       models:
         project:
-          destroy:
-            must_be_archived_to_destroy: "Um projeto deve estar arquivado antes de ser removido."
+          must_be_archived_to_destroy: "Um projeto deve estar arquivado antes de ser removido."
         issue:
-          destroy:
-            must_be_archived_to_destroy: "Uma issue deve estar arquivada antes de ser removida."
+          must_be_archived_to_destroy: "Uma issue deve estar arquivada antes de ser removida."

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -60,7 +60,7 @@ en:
     preview: "Preview"
     press: "Press"
     go_to_board: 'Go to workflow board'
-    go_to_issue: 'Go to Issue'
+    go_to_issue: 'Go to issue'
     go_to_issues_list: 'Go to issues list'
     go_to_time_tracking: "Go to time tracking"
     start_time_tracking: "Track time"

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -84,8 +84,8 @@ en:
       unarchive:
         notice: "%{resource_name} was successfully unarchived."
       destroy:
-        notice: "%{resource_name} was successfully destroyed."
-        alert: "%{resource_name} could not be destroyed."
+        notice: "%{resource_name} was successfully removed."
+        alert: "%{resource_name} could not be removed."
       mark_as_read:
         notice: "Notification was marked as read"
       mark_all_as_read:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
         member do
           post :add_label
           delete :remove_label
+          put :archive
+          put :unarchive
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,8 +66,6 @@ Rails.application.routes.draw do
         member do
           post :add_label
           delete :remove_label
-          put :archive
-          put :unarchive
         end
       end
 
@@ -81,6 +79,8 @@ Rails.application.routes.draw do
   resources :issues, only: [ :destroy ] do
     member do
       patch :pick_grouping
+      put :archive
+      put :unarchive
     end
     scope module: "issues" do
       resource :file, only: [ :destroy ] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   mount ActionCable.server => "/cable"
 
-  resources :projects, except: [ :destroy ] do
+  resources :projects do
     member do
       put :archive
       put :unarchive

--- a/db/migrate/20250320021144_add_archived_at_to_issues.rb
+++ b/db/migrate/20250320021144_add_archived_at_to_issues.rb
@@ -1,0 +1,6 @@
+class AddArchivedAtToIssues < ActiveRecord::Migration[8.0]
+  def change
+    add_column :issues, :archived_at, :datetime
+    add_index :issues, :archived_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_04_171250) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_20_021144) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -95,6 +95,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_04_171250) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "project_id"
+    t.datetime "archived_at"
+    t.index ["archived_at"], name: "index_issues_on_archived_at"
     t.index ["project_id"], name: "index_issues_on_project_id"
   end
 

--- a/spec/factories/issue.rb
+++ b/spec/factories/issue.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     sequence(:title) { |n| "My issue #{n}" }
     sequence(:description) { |n| "Issue #{n} description" }
 
+    trait :archived do
+      archived_at { Date.current }
+    end
+
     transient do
       with_labels { [] }
     end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -13,15 +13,19 @@ FactoryBot.define do
     time_tracking_enabled { true }
 
     transient do
+      issue_counts { 0 }
       visualization_counts { 1 }
       with_issue_labels { [] }
     end
 
     after(:create) do |project, evaluator|
       create_list(:visualization, evaluator.visualization_counts, project: project)
+
       evaluator.with_issue_labels.each do |label|
         create(:issue_label, title: label, project:)
       end
+
+      create_list(:issue, evaluator.issue_counts, project: project)
     end
   end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -6,6 +6,10 @@ FactoryBot.define do
       "Project #{i}"
     end
 
+    trait :archived do
+      archived_at { Date.current }
+    end
+
     time_tracking_enabled { true }
 
     transient do

--- a/spec/features/project_management/all_issues/listing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/listing_issues_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+describe 'As a project manager, I want to list my issues' do
+  let!(:user) { FactoryBot.create(:user) }
+
+  specify "It lists active issues by default" do
+    project = FactoryBot.create(:project)
+
+    FactoryBot.create(:issue, project: project, title: "Implement new feature")
+    FactoryBot.create(:issue, :archived, project: project, title: "Archived issue")
+
+    visit project_issues_path(project)
+
+    expect(page).to have_content("Implement new feature")
+    expect(page).not_to have_content("Archived issue")
+  end
+
+  specify "I can filter issues by archiving status" do
+    project = FactoryBot.create(:project)
+
+    FactoryBot.create(:issue, project: project, title: "Implement new feature")
+    FactoryBot.create(:issue, project: project, title: "Debug code")
+    FactoryBot.create(:issue, :archived, project: project, title: "Archived issue")
+
+    visit project_issues_path(project)
+
+    within ".cpy-filter-form" do
+      select "List only archived issues", from: "q[by_archiving_status]"
+
+      click_button "Search"
+    end
+
+    expect(page).to have_content("Archived issue")
+    expect(page).not_to have_content("Implement new feature")
+    expect(page).not_to have_content("Debug code")
+
+    within ".cpy-filter-form" do
+      select "List only active issues", from: "q[by_archiving_status]"
+
+      click_button "Search"
+    end
+
+    expect(page).to have_content("Implement new feature")
+    expect(page).to have_content("Debug code")
+    expect(page).not_to have_content("Archived issue")
+
+
+    within ".cpy-filter-form" do
+      select "List all issues", from: "q[by_archiving_status]"
+
+      click_button "Search"
+    end
+
+    expect(page).to have_content("Implement new feature")
+    expect(page).to have_content("Debug code")
+    expect(page).to have_content("Archived issue")
+  end
+end

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -176,7 +176,7 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     expect(page).not_to have_content("Issue testing title")
 
-    expect(page).to have_content("Issue was successfully destroyed.")
+    expect(page).to have_content("Issue was successfully removed.")
 
     expect(Issue.where(id: issue.id)).not_to be_present
   end
@@ -200,7 +200,7 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     expect(page).not_to have_content("Issue testing title")
 
-    expect(page).to have_content("Issue was successfully destroyed.")
+    expect(page).to have_content("Issue was successfully removed.")
 
     expect(Issue.where(id: issue.id)).not_to be_present
   end

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -161,50 +161,6 @@ describe 'As a project manager, I want to manage my issues from all issues' do
     end
   end
 
-  specify "I can delete issues directly from list" do
-    project = FactoryBot.create(:project)
-
-    issue = FactoryBot.create(:issue, title: "Issue testing title", project: project)
-
-    visit project_issues_path(project)
-
-    within dom_id(issue) do
-      accept_confirm do
-        find(".cpy-delete-button").click
-      end
-    end
-
-    expect(page).not_to have_content("Issue testing title")
-
-    expect(page).to have_content("Issue was successfully removed.")
-
-    expect(Issue.where(id: issue.id)).not_to be_present
-  end
-
-  specify "I can delete issue from issue modal" do
-    project = FactoryBot.create(:project)
-
-    issue = FactoryBot.create(:issue, title: "Issue testing title", project: project)
-
-    visit project_issues_path(project)
-
-    within dom_id(issue) do
-      find(".cpy-edit-button").click
-    end
-
-    within ".cpy-issue-detail" do
-      accept_confirm do
-        click_link "Remove"
-      end
-    end
-
-    expect(page).not_to have_content("Issue testing title")
-
-    expect(page).to have_content("Issue was successfully removed.")
-
-    expect(Issue.where(id: issue.id)).not_to be_present
-  end
-
   specify "I can start time tracking for an issue" do
     project = FactoryBot.create(:project)
 

--- a/spec/features/project_management/all_issues/purging_issues_spec.rb
+++ b/spec/features/project_management/all_issues/purging_issues_spec.rb
@@ -27,15 +27,17 @@ describe "As a project manager, I want to manage issue archive status" do
 
     expect(non_archived_issue).to be_archived
 
-    within 'table' do
-      expect(page).not_to have_content(non_archived_issue.title)
+    within "table #issue_#{non_archived_issue.id}" do
+      expect(page).to have_content("Archived")
     end
   end
 
   specify "I can unarchive an issue" do
     visit project_issues_path(project)
 
-    within dom_id(archieved_issue) do
+    select "List only archived issues", from: "q[by_archiving_status]"
+
+    within "table #issue_#{archieved_issue.id}" do
       click_link('Go to issue')
     end
 
@@ -50,6 +52,10 @@ describe "As a project manager, I want to manage issue archive status" do
     archieved_issue.reload
 
     expect(archieved_issue).not_to be_archived
+
+    within "table #issue_#{archieved_issue.id}" do
+      expect(page).to_not have_content("Active")
+    end
   end
 end
 
@@ -64,7 +70,9 @@ describe "As a project manager, I want to remove an issue" do
   specify "I can remove an archived issue" do
     visit project_issues_path(project)
 
-    within dom_id(archieved_issue) do
+    select "List only archived issues", from: "q[by_archiving_status]"
+
+    within "table #issue_#{archieved_issue.id}" do
       click_link('Go to issue')
     end
 

--- a/spec/features/project_management/all_issues/purging_issues_spec.rb
+++ b/spec/features/project_management/all_issues/purging_issues_spec.rb
@@ -1,0 +1,96 @@
+require 'rails_helper'
+
+describe "As a project manager, I want to manage issue archive status" do
+  let!(:user) { FactoryBot.create(:user) }
+
+  let!(:project) { FactoryBot.create(:project) }
+
+  let!(:archieved_issue) { FactoryBot.create(:issue, :archived, project: project) }
+  let!(:non_archived_issue) { FactoryBot.create(:issue, project: project) }
+
+  specify "I can archive an issue" do
+    visit project_issues_path(project)
+
+    within dom_id(non_archived_issue) do
+      click_link('Go to issue')
+    end
+
+    within '.cpy-issue-detail' do
+      accept_confirm do
+        click_link('Archive')
+      end
+    end
+
+    expect(page).to have_content("Issue was successfully archived.")
+
+    non_archived_issue.reload
+
+    expect(non_archived_issue).to be_archived
+
+    within 'table' do
+      expect(page).not_to have_content(non_archived_issue.title)
+    end
+  end
+
+  specify "I can unarchive an issue" do
+    visit project_issues_path(project)
+
+    within dom_id(archieved_issue) do
+      click_link('Go to issue')
+    end
+
+    within '.cpy-issue-detail' do
+      accept_confirm do
+        click_link('Unarchive')
+      end
+    end
+
+    expect(page).to have_content("Issue was successfully unarchived.")
+
+    archieved_issue.reload
+
+    expect(archieved_issue).not_to be_archived
+  end
+end
+
+describe "As a project manager, I want to remove an issue" do
+  let!(:user) { FactoryBot.create(:user) }
+
+  let!(:project) { FactoryBot.create(:project) }
+
+  let!(:archieved_issue) { FactoryBot.create(:issue, :archived, project: project) }
+  let!(:non_archived_issue) { FactoryBot.create(:issue, project: project) }
+
+  specify "I can remove an archived issue" do
+    visit project_issues_path(project)
+
+    within dom_id(archieved_issue) do
+      click_link('Go to issue')
+    end
+
+    within '.cpy-issue-detail' do
+      accept_confirm do
+        click_link('Remove')
+      end
+    end
+
+    expect(page).to have_content("Issue was successfully removed.")
+
+    expect(Issue.exists?(archieved_issue.id)).to be_falsey
+    within 'table' do
+      expect(page).not_to have_content(archieved_issue.title)
+    end
+  end
+
+  specify "I can't remove an issue that is not archived" do
+    visit project_issues_path(project)
+
+    within dom_id(non_archived_issue) do
+      click_link('Go to issue')
+    end
+
+    within '.cpy-issue-detail' do
+      expect(page).not_to have_link('Remove')
+    end
+  end
+end

--- a/spec/features/project_management/managing_issue_labels_spec.rb
+++ b/spec/features/project_management/managing_issue_labels_spec.rb
@@ -106,7 +106,7 @@ describe 'As a project manager, I want to manage my issue labels' do
       end
     end
 
-    expect(page).to have_content("Issue Label was successfully destroyed.")
+    expect(page).to have_content("Issue Label was successfully removed.")
 
     within 'table' do
       expect(page).to_not have_content("Development")

--- a/spec/features/project_management/managing_projects_spec.rb
+++ b/spec/features/project_management/managing_projects_spec.rb
@@ -147,4 +147,32 @@ context "As a user, I want to manage my projects" do
 
     expect(page).to have_current_path(time_entries_path(new_entry: { project_id: project_beta.id }))
   end
+
+  describe "Removing a project" do
+    it "can be removed if it's archived" do
+      project = create(:project, :archived)
+
+      visit projects_path
+
+      within dom_id(project) do
+        page.accept_alert do
+          click_link('Remove')
+        end
+      end
+
+      expect(page).to have_content("Project was successfully removed.")
+
+      expect(Project.exists?(project.id)).to be_falsey
+    end
+
+    it "can't be removed if it is not archived" do
+      project = create(:project)
+
+      visit projects_path
+
+      within dom_id(project) do
+        expect(page).to_not have_link('Remove')
+      end
+    end
+  end
 end

--- a/spec/features/project_management/using_views/kanban/filtering_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/filtering_issues_spec.rb
@@ -35,6 +35,18 @@ describe 'As a project manager, I want to filter my issues from kanban boards' d
     grouping_done.issues << issue_deploy
   end
 
+  specify "It lists only active issues" do
+    issue_development1.archive!
+    issue_development2.archive!
+    visit visualization_path(project.default_visualization)
+
+    within '.cpy-columns-wrapper' do
+      expect(page).to_not have_content("Bigtask 1")
+      expect(page).to_not have_content("Bigtask 2")
+      expect(page).to have_content("Bigtask 3")
+    end
+  end
+
   specify "I can filter by issue title" do
     visit visualization_path(project.default_visualization)
 
@@ -49,7 +61,6 @@ describe 'As a project manager, I want to filter my issues from kanban boards' d
       expect(page).to have_content("Bigtask 3")
     end
   end
-
 
   specify "I can filter by issue labels" do
     visit visualization_path(project.default_visualization)

--- a/spec/features/project_management/using_views/kanban/managing_groupings_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_groupings_spec.rb
@@ -71,7 +71,7 @@ describe 'As a user, I want to manage my kanban view columns' do
       end
     end
 
-    expect(page).to have_content("Column was successfully destroyed.")
+    expect(page).to have_content("Column was successfully removed.")
 
     expect(Grouping.where(id: grouping.id)).not_to be_present
 

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -243,27 +243,6 @@ describe 'As a user, I want to manage my project using a kanban view' do
     expect(Grouping.find_by(title: "Done").allocations.first.issue.title).to eq("Issue 1")
   end
 
-  specify 'I can delete issues' do
-    project = FactoryBot.create(:project)
-    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
-    issue = FactoryBot.create(:issue, project: project, title: "DELETE ME")
-    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
-
-    visit visualization_path(project.default_visualization)
-
-    click_link "DELETE ME"
-
-    within ".cpy-issue-detail" do
-      accept_confirm do
-        click_link "Remove"
-      end
-    end
-
-    expect(page).to have_content("Issue was successfully removed.")
-
-    expect(Issue.where(id: issue.id)).not_to be_present
-  end
-
   specify 'I can change issue grouping on the issue detail modal' do
     project = FactoryBot.create(:project)
     grouping = FactoryBot.create(:grouping, visualization: project.default_visualization, title: "First grouping")

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -259,7 +259,7 @@ describe 'As a user, I want to manage my project using a kanban view' do
       end
     end
 
-    expect(page).to have_content("Issue was successfully destroyed.")
+    expect(page).to have_content("Issue was successfully removed.")
 
     expect(Issue.where(id: issue.id)).not_to be_present
   end

--- a/spec/features/project_management/using_views/kanban/purging_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/purging_issues_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+describe "As a project manager, I want to achieve a issue from kanban board" do
+  let!(:user) { FactoryBot.create(:user) }
+
+  let!(:project) { FactoryBot.create(:project) }
+
+  let!(:grouping) { FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO") }
+
+  let!(:issue) { FactoryBot.create(:issue, project: project, title: "DELETE ME") }
+
+  let!(:archived_issue) { FactoryBot.create(:issue, :archived, project: project, title: "ARCHIVED ISSUE") }
+
+  before(:each) do
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+    FactoryBot.create(:grouping_issue_allocation, issue: archived_issue, grouping: grouping)
+  end
+
+  def archive_issue(issue)
+    visit visualization_path(project.default_visualization)
+
+    click_link issue.title
+
+    within ".cpy-issue-detail" do
+      accept_confirm do
+        click_link "Archive"
+      end
+    end
+  end
+
+  specify 'I can archive an issue' do
+    archive_issue(issue)
+
+    expect(page).to have_content("Issue was successfully archived.")
+
+    issue.reload
+
+    expect(issue).to be_archived
+
+    within ".cpy-issue-detail" do
+      expect(page).not_to have_link("Archive")
+      expect(page).to have_link("Unarchive")
+    end
+  end
+
+  specify "I can remove an issue immediately after archiving it" do
+    archive_issue(issue)
+
+    within ".cpy-issue-detail" do
+      accept_confirm do
+        click_link "Remove"
+      end
+    end
+
+    expect(page).to have_content("Issue was successfully removed.")
+
+    expect(Issue.exists?(issue.id)).to be_falsey
+  end
+
+  specify "I can unarchive an issue" do
+    visit visualization_path(project.default_visualization)
+
+    click_link archived_issue.title
+
+    within ".cpy-issue-detail" do
+      accept_confirm do
+        click_link "Unarchive"
+      end
+    end
+
+    expect(page).to have_content("Issue was successfully unarchived.")
+
+    issue.reload
+
+    expect(issue).not_to be_archived
+
+    within ".cpy-issue-detail" do
+      expect(page).not_to have_link("Unarchive")
+      expect(page).to have_link("Archive")
+    end
+  end
+end

--- a/spec/features/project_management/using_views/kanban/purging_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/purging_issues_spec.rb
@@ -56,27 +56,4 @@ describe "As a project manager, I want to achieve a issue from kanban board" do
 
     expect(Issue.exists?(issue.id)).to be_falsey
   end
-
-  specify "I can unarchive an issue" do
-    visit visualization_path(project.default_visualization)
-
-    click_link archived_issue.title
-
-    within ".cpy-issue-detail" do
-      accept_confirm do
-        click_link "Unarchive"
-      end
-    end
-
-    expect(page).to have_content("Issue was successfully unarchived.")
-
-    issue.reload
-
-    expect(issue).not_to be_archived
-
-    within ".cpy-issue-detail" do
-      expect(page).not_to have_link("Unarchive")
-      expect(page).to have_link("Archive")
-    end
-  end
 end

--- a/spec/features/time_entries/navigating_links_in_time_entry_form_spec.rb
+++ b/spec/features/time_entries/navigating_links_in_time_entry_form_spec.rb
@@ -10,7 +10,7 @@ describe 'As a user, I want to see appropriate links in the time entry form' do
     visit time_entries_path(new_entry: { project_id: project.id })
 
     within '#time_entry_form' do
-      expect(page).not_to have_link("Go to Issue", exact: true)
+      expect(page).not_to have_link("Go to issue", exact: true)
       click_link("Go to issues list")
       expect(page).to have_current_path(project_issues_path(project))
     end
@@ -21,7 +21,7 @@ describe 'As a user, I want to see appropriate links in the time entry form' do
 
     within '#time_entry_form' do
       expect(page).not_to have_link("Go to issues list", exact: true)
-      click_link("Go to Issue")
+      click_link("Go to issue")
       expect(page).to have_current_path(project_show_issue_path(project, issue.id))
     end
   end
@@ -31,14 +31,14 @@ describe 'As a user, I want to see appropriate links in the time entry form' do
 
     within '#time_entry_form' do
       expect(page).to have_link("Go to issues list", exact: true)
-      expect(page).not_to have_link("Go to Issue", exact: true)
+      expect(page).not_to have_link("Go to issue", exact: true)
     end
 
     select_from_select2(selector: '#project_dependent_fields .select2', option_text: issue.title)
 
     within '#time_entry_form' do
       expect(page).not_to have_link("Go to issues list", exact: true)
-      expect(page).to have_link("Go to Issue", href: project_show_issue_path(project, issue.id), exact: true)
+      expect(page).to have_link("Go to issue", href: project_show_issue_path(project, issue.id), exact: true)
     end
   end
 end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -4,7 +4,7 @@ describe Issue do
   let(:project) { create(:project) }
   let(:issue) { create(:issue, project: project) }
 
-  describe "Removal is only possible if the project is archived" do
+  describe "Removal is only possible if the issue is archived" do
     it "can be removed if it is archived" do
       issue = create(:issue, :archived, project: project)
       expect(issue.destroy).to be_truthy

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -4,6 +4,19 @@ describe Issue do
   let(:project) { create(:project) }
   let(:issue) { create(:issue, project: project) }
 
+  describe "Removal is only possible if the project is archived" do
+    it "can be removed if it is archived" do
+      issue = create(:issue, :archived, project: project)
+      expect(issue.destroy).to be_truthy
+    end
+
+    it "can't be removed if it is not archived" do
+      expect(issue.destroy).to be_falsey
+      expect(issue.errors.full_messages).to include("Issue must be archived before it can be removed.")
+    end
+  end
+
+
   describe 'labels_list implementation' do
     context 'when given a comma-separated string' do
       it 'sets the labels_list but not the labels' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe Project do
-
   describe "Removal is only possible if the project is archived" do
     it "can be removed if it is archived" do
       project = create(:project, :archived)
@@ -11,6 +10,7 @@ describe Project do
     it "can't be removed if it is not archived" do
       project = create(:project)
       expect(project.destroy).to be_falsey
+      expect(project.errors.full_messages).to include("Project must be archived before it can be removed.")
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,6 +1,19 @@
 require 'rails_helper'
 
 describe Project do
+
+  describe "Removal is only possible if the project is archived" do
+    it "can be removed if it is archived" do
+      project = create(:project, :archived)
+      expect(project.destroy).to be_truthy
+    end
+
+    it "can't be removed if it is not archived" do
+      project = create(:project)
+      expect(project.destroy).to be_falsey
+    end
+  end
+
   describe "Using templates" do
     let(:project) { build(:project, visualization_counts: 0, with_issue_labels: []) }
     describe '#use_template=' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -7,6 +7,20 @@ describe Project do
       expect(project.destroy).to be_truthy
     end
 
+    it "Removes all dependencies when removed" do
+      project = create(:project, :archived, issue_counts: 2)
+      expect(project.issues.count).to eq(2)
+      expect(project.visualizations.count).to eq(1)
+      expect(project.issue_labels.count).to eq(0)
+
+      project.destroy
+
+      expect(project).to be_destroyed
+      expect(project.issues.count).to eq(0)
+      expect(project.visualizations.count).to eq(0)
+      expect(project.issue_labels.count).to eq(0)
+    end
+
     it "can't be removed if it is not archived" do
       project = create(:project)
       expect(project.destroy).to be_falsey


### PR DESCRIPTION
This PR implements archiving/removing flow for projects and issues. It also changes how these entities are filtered and displayed in the UI. Now we can delete as much projects or issues as we want. 
![image](https://github.com/user-attachments/assets/3b102a57-46f3-4f68-bebd-185aa012c563)

# Project List

- Implemented remove feature
- If the user tries to access an archived project, they can. There's no point in validating as the system has only one user.

![project-purge](https://github.com/user-attachments/assets/5bd1af04-a2c6-49f8-9825-5f267b29d6f0)

# Issues

## List filtering
- Listing only active (non archived) issues by default
- All / Archived / Unarchived custom filter on all issues list. It submits the filter on select change.

![list-issue-archive](https://github.com/user-attachments/assets/53c92b8f-6102-4a6a-959a-24ba718ba088)

## Archiving
- Removed the "remove" button from the list item
- Archive / Unarchive / Remove actions buttons available only on issue detail modal 
- Archiving / Unarchiving an issue, doesn't remove the table item. Only updates the row.

![list-issue-archive](https://github.com/user-attachments/assets/ccb3f59a-cdc9-4ceb-a085-57da2d18edcd)

# Board
- Board lists only active issues (no custom filter here)
- Archive / Unarchive / Remove actions buttons available only on issue detail modal 
- If an issue is Archive, the card is removed (modal is still open)
- If you archived and issue and unarchived it right after the card appears back
- If you archive and close the modal you'll have to go to "All issues list" to unarchive it

![board-archive](https://github.com/user-attachments/assets/b978dcdf-eea4-4765-9e8b-244280d85323)

# Time entry
- Time entries form doesn't list archived projects on select
- Time entries form doesn't list archived issues on select
- Existing time entries can be updated
- There is no validation on the backend

![image](https://github.com/user-attachments/assets/471b5503-3870-4982-8a42-3556cb45a848)
![image](https://github.com/user-attachments/assets/09885941-0f8b-41cd-9a58-fe54d5568549)

# Extra
- Changed default feedback message for "Entity  was successfully destroyed." to "Entity was successfully removed."

In another PR we can:
- Issues specs were created in a separate fiel to avoid conflicts with PRO Edition code. 
- Discuss a some standards for naming specs and bring some changes already made in the pro edition to here 
- Create a concern for archiving things?
- Reuse some of them (issue modal/management) with a shared context. This one I'm not sure if it's necessary

