### PR TITLE
Fixes board "Create issue" button behaviour

### DIFF
--- a/app/assets/tailwind/themes/_components/visualizations/board.css
+++ b/app/assets/tailwind/themes/_components/visualizations/board.css
@@ -36,6 +36,10 @@
 
       &:hover {
         @apply flex;
+
+        .board--column--create-button-shortcut {
+          @apply flex;
+        }
       }
     }
 

--- a/app/assets/tailwind/themes/_components/visualizations/board.css
+++ b/app/assets/tailwind/themes/_components/visualizations/board.css
@@ -43,6 +43,21 @@
       }
     }
 
+    .inline-card-form {
+      @apply flex-col mt-2;
+      display: none;
+    }
+
+    &.card-form-showing {
+      .inline-card-form {
+        display: flex;
+      }
+
+      .board--column--create-button {
+        display: none;
+      }
+    }
+
     &.collapsed {
       .board--column--header {
         @apply flex-col;

--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -33,14 +33,12 @@ export default class extends Controller {
   }
 
   showInlineCardForm() {
-    this.inlineCardFormTarget.classList.remove('hidden')
-    this.showFormButtonTarget.classList.add('hidden')
+    this.element.classList.add('card-form-showing')
     this.inlineCardFormTitleTarget.focus()
   }
 
   hideInlineCardForm() {
-    this.showFormButtonTarget.classList.remove('hidden')
-    this.inlineCardFormTarget.classList.add('hidden')
+    this.element.classList.remove('card-form-showing')
   }
 
   cardTargetConnected(cardElement) {

--- a/app/views/visualizations/_column/_inline_card_form.html.erb
+++ b/app/views/visualizations/_column/_inline_card_form.html.erb
@@ -1,6 +1,6 @@
 
 <%= form_with(model: [visualization, Issue.new], html: {
-    class: 'flex flex-col mt-2 hidden',
+    class: 'inline-card-form',
     id: "grouping-#{grouping.id}-inline-issue-form",
     data: {
       'grouping-column-target': 'inlineCardForm',


### PR DESCRIPTION
# Fix 1 - Press N Shortcut not showing on hover

Now, when we hover "Create issue" button the press n tip appears

<img width="300" alt="image" src="https://github.com/user-attachments/assets/c7449996-5bae-45cf-aeca-94767a7b98d8" />

# Fix 2 - Create issue button should disappear after press

Now, if the column is showing the card form, the "Create issue" button dissapear

<img width="300" alt="image" src="https://github.com/user-attachments/assets/8723db09-5085-41c8-9f18-e76504b32d8a" />
