### PR TITLE
chore: Adds new markdown editor

### DIFF
--- a/app/assets/tailwind/themes/_components/all.css
+++ b/app/assets/tailwind/themes/_components/all.css
@@ -3,3 +3,4 @@
 @import "./link";
 @import "./table";
 @import "./visualizations/board";
+@import "./markdown-editor/all";

--- a/app/assets/tailwind/themes/_components/markdown-editor/all.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/all.css
@@ -1,0 +1,5 @@
+@import "./prosemirror";
+@import "./prosemirror-tables";
+@import "./common";
+@import "./variables";
+@import "./components/all";

--- a/app/assets/tailwind/themes/_components/markdown-editor/common.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/common.css
@@ -1,0 +1,166 @@
+.milkdown {
+  position: relative;
+  border: 0 solid;
+  box-sizing: border-box;
+
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  button,
+  input {
+    border: none;
+    background: none;
+    box-shadow: none;
+    &:focus {
+      outline: none;
+    }
+  }
+
+  :focus-visible {
+    outline: none;
+  }
+
+  font-family: var(--font-default);
+  color: var(--color-on-background);
+  background: var(--color-background);
+
+  .ProseMirror-focused {
+    outline: none;
+  }
+
+  .milkdown-menu {
+    background-color: var(--menu-bg);
+    overflow-x: scroll;
+    border: 1px var(--menu-border) solid;
+    border-radius: 0.1rem;
+  }
+
+  .milkdown-menu::-webkit-scrollbar {
+    height: 2px;
+    background-color: transparent;
+  }
+
+  .milkdown-menu::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background-color: #81a1c161;
+    border: 0px solid transparent;
+    background-clip: content-box;
+  }
+
+  .milkdown-menu::-webkit-scrollbar-track {
+    border-radius: 999px;
+    background: transparent;
+    border: 4px solid transparent;
+  }
+
+  .milkdown-menu ul {
+    list-style: none;
+  }
+
+  .milkdown-menu button {
+    border: none;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0.5rem 0.5rem;
+    box-sizing: border-box;
+    width: 30px;
+    height: 30px;
+    font-size: 1rem;
+    background-color: transparent;
+    color: var(--menu-text-color);
+    cursor: pointer;
+  }
+
+  .milkdown-menu button:not(:only-child) {
+    min-width: 120px;
+    justify-content: space-between;
+  }
+
+  .milkdown-menu button:not(:only-child) > span {
+    transition: transform 0.2s ease-in;
+  }
+
+  .milkdown-menu button:not(:only-child):where([aria-expanded='true']) > span {
+    transform: rotate(-180deg);
+  }
+
+  .milkdown-menu button:hover,
+  .milkdown-menu button.active {
+    background: var(--menu-bg-hover);
+    border-radius: 0.1rem;
+  }
+
+  .milkdown-menu div[role='separator'] {
+    flex-shrink: 0;
+    width: 1px;
+    background-color: var(--menu-border);
+    margin: 7px 5px;
+    min-height: 24px;
+  }
+
+  .milkdown-menu ul[role='menubar'] {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    gap: 4px;
+    padding: 0 4px;
+  }
+
+  .milkdown-menu ul[role='menu'] {
+    display: none;
+    margin: 0;
+    padding: 0;
+    position: absolute;
+    border: 1px solid var(--menu-border);
+    background-color: var(--menu-bg);
+    z-index: 100;
+  }
+
+  .milkdown-menu ul[role='menu'].show {
+    display: block;
+  }
+
+  .milkdown-menu ul[role='menu'] li[role='menuitem'] {
+    padding: 6px;
+    color: white;
+    cursor: pointer;
+    padding: 0.75rem 1rem;
+    font-size: 14px;
+    min-width: 120px;
+  }
+
+  .milkdown-menu ul[role='menu'] li[role='menuitem']:is(:hover, :focus) {
+    background-color: var(--menu-bg-hover);
+    color: var(--menu-text-hover);
+  }
+
+  .ProseMirror {
+    border: 1px solid #ddd;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    padding: 10px;
+
+    li.ProseMirror-selectednode:after {
+      all: unset;
+    }
+
+    .ProseMirror-selectednode {
+      background: var(--color-selected);
+      outline: none;
+      background: color-mix(
+        in srgb,
+        var(--color-selected),
+        transparent 60%
+      );
+    }
+
+    a {
+      color: var(--color-primary);
+      text-decoration: underline;
+    }
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/all.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/all.css
@@ -1,0 +1,8 @@
+@import "./code";
+@import "./quote";
+@import "./divider";
+@import "./typograph";
+@import "./list";
+@import "./link";
+@import "./table";
+@import "./image";

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/code.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/code.css
@@ -1,0 +1,31 @@
+.milkdown {
+  pre {
+    background: color-mix(
+      in srgb,
+      var(--color-code-background),
+      transparent 40%
+    );
+    padding: 10px;
+    border-radius: 4px;
+
+    code {
+      padding: 0;
+      background: transparent;
+    }
+  }
+
+  code {
+    color: var(--color-code-text);
+    background: color-mix(
+      in srgb,
+      var(--color-code-background),
+      transparent 40%
+    );
+    font-family: var(--font-code);
+    padding: 0 10px;
+    border-radius: 4px;
+    font-size: 87.5%;
+    display: inline-block;
+    line-height: 1.4286;
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/divider.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/divider.css
@@ -1,0 +1,38 @@
+.milkdown {
+  hr {
+    border: none;
+    background-color: color-mix(
+      in srgb,
+      var(--color-divider),
+      transparent 80%
+    );
+    background-clip: content-box;
+    padding: 6px 0;
+    height: 13px;
+    position: relative;
+
+    &.ProseMirror-selectednode {
+      outline: none;
+      background-color: color-mix(
+        in srgb,
+        var(--color-divider),
+        transparent 20%
+      );
+      background-clip: content-box;
+      &::before {
+        content: '';
+        position: absolute;
+        left: 0;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        background-color: color-mix(
+          in srgb,
+          var(--color-divider),
+          transparent 80%
+        );
+        pointer-events: none;
+      }
+    }
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/image.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/image.css
@@ -1,0 +1,187 @@
+.milkdown {
+  milkdown-image-block.selected > .image-edit {
+    outline: 2px solid fuchsia;
+  }
+
+  milkdown-image-block.selected > .image-wrapper img {
+    outline: 2px solid fuchsia;
+  }
+
+  milkdown-image-block > .image-wrapper .operation {
+    gap: 16px;
+    right: 16px;
+    top: 16px;
+    opacity: 0;
+    transition: all 0.2s;
+  }
+
+  milkdown-image-block:hover > .image-wrapper .operation {
+    opacity: 1;
+  }
+
+  milkdown-image-block > .image-wrapper .operation > .operation-item {
+    color: antiquewhite;
+    padding: 8px;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 50%;
+    height: 28px;
+    width: 28px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  milkdown-image-block > .image-wrapper .image-resize-handle {
+    height: 8px;
+    bottom: -4px;
+    width: 160px;
+    background: antiquewhite;
+    opacity: 0;
+    transition: all 0.2s;
+  }
+
+  milkdown-image-block:hover > .image-wrapper .image-resize-handle {
+    opacity: 1;
+  }
+
+  milkdown-image-block > .caption-input {
+    margin: 16px auto;
+  }
+
+  milkdown-image-block > .image-edit {
+    align-items: center;
+    padding: 16px 24px;
+    gap: 16px;
+    background: oldlace;
+    height: 56px;
+  }
+
+  milkdown-image-block > .image-edit .image-icon {
+    color: darkgray;
+  }
+
+  milkdown-image-block > .image-edit .image-icon svg {
+    width: 24px;
+    height: 24px;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder {
+    color: darkgray;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .link-input-area {
+    line-height: 24px;
+    padding: 8px 0;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder .uploader {
+    gap: 8px;
+    color: fuchsia;
+    justify-content: center;
+    transition: color 0.2s;
+  }
+
+  milkdown-image-block > .image-edit .link-importer.focus .placeholder .uploader {
+    color: unset;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder .uploader:hover {
+    color: fuchsia;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder .text {
+    margin-left: 8px;
+  }
+
+  milkdown-image-block > .image-edit .confirm {
+    background: darkgray;
+    color: antiquewhite;
+    line-height: 40px;
+    padding: 0 24px;
+    border-radius: 100px;
+    font-size: 14px;
+  }
+
+  milkdown-image-block {
+    outline: none;
+    margin: 16px 0;
+    display: block;
+  }
+
+  milkdown-image-block > .image-wrapper {
+    position: relative;
+    width: fit-content;
+    margin: 0 auto;
+    min-width: 100px;
+  }
+
+  milkdown-image-block > .image-wrapper .operation {
+    position: absolute;
+    display: flex;
+  }
+
+  milkdown-image-block > .image-wrapper .operation > .operation-item {
+    cursor: pointer;
+  }
+
+  milkdown-image-block > .image-wrapper img {
+    max-width: 100%;
+    min-height: 100px;
+    display: block;
+    object-fit: cover;
+  }
+
+  milkdown-image-block > .image-wrapper > .image-resize-handle {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  milkdown-image-block > .image-wrapper > .image-resize-handle:hover {
+    cursor: row-resize;
+  }
+
+  milkdown-image-block input {
+    background: transparent;
+    outline: none;
+    border: 0;
+  }
+
+  milkdown-image-block > .caption-input {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  milkdown-image-block > .image-edit {
+    display: flex;
+  }
+
+  milkdown-image-block > .image-edit .confirm {
+    cursor: pointer;
+  }
+
+  milkdown-image-block > .image-edit .link-importer {
+    position: relative;
+    flex: 1;
+  }
+
+  milkdown-image-block > .image-edit .link-importer > .link-input-area {
+    width: 100%;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    cursor: text;
+  }
+
+  milkdown-image-block > .image-edit .link-importer .placeholder .uploader {
+    cursor: pointer;
+    display: flex;
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/link.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/link.css
@@ -1,0 +1,60 @@
+.milkdown {
+  milkdown-link-preview, milkdown-link-edit {
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+    overflow: hidden;
+    border-radius: 0.25rem;
+    position: absolute;
+
+    &[data-show='false'] {
+      display: none;
+    }
+
+    .link-preview, .link-edit {
+      background-color: var(--color-link-tooltip-background);
+      display: flex;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.5rem;
+      cursor: pointer;
+      height: 2.5rem;
+
+      .link-icon {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .link-display {
+        width: 240px;
+        line-height: 24px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 14px;
+        text-wrap: nowrap;
+
+        &:empty {
+          display: none;
+        }
+      }
+
+      .button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.25rem;
+        border-radius: 9999px;
+
+        &:hover {
+          background-color: var(--color-link-tooltip-background-hover);
+        }
+      }
+
+      .input-area {
+        outline: none;
+        background-color: transparent;
+        width: 13rem;
+        font-size: 0.875rem;
+      }
+    }
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/list.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/list.css
@@ -1,0 +1,25 @@
+.milkdown {
+  ul,
+  ol {
+    padding: 0;
+    list-style: none;
+  }
+
+  milkdown-list-item-block {
+    li {
+      gap: 10px;
+    }
+
+    .list-item {
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      flex-wrap: nowrap;
+    }
+
+    input[type="checkbox"] {
+      border: solid var(--color-list-checkbox-border) 1px;
+    }
+  }
+
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/quote.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/quote.css
@@ -1,0 +1,25 @@
+.milkdown {
+  blockquote {
+    position: relative;
+    padding-left: 40px;
+    padding-top: 0;
+    padding-bottom: 0;
+    box-sizing: content-box;
+    margin: 4px 0;
+
+    &::before {
+      content: '';
+      width: 4px;
+      left: 0;
+      top: 4px;
+      bottom: 4px;
+      position: absolute;
+      background: var(--color-quote-marker);
+      border-radius: 100px;
+    }
+
+    hr {
+      margin-bottom: 16px;
+    }
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/table.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/table.css
@@ -1,0 +1,131 @@
+.milkdown {
+  th,td {
+    border: 1px solid var(--color-table-border);
+  }
+
+  milkdown-table-block {
+    display: block;
+    margin: 4px 0;
+  }
+
+  milkdown-table-block table {
+    margin: 0 !important;
+    border-radius: 0 !important;
+  }
+
+  milkdown-table-block .handle {
+    position: absolute;
+    z-index: 50;
+    cursor: grab;
+    font-size: 14px;
+  }
+
+  milkdown-table-block .cell-handle {
+    left: -999px;
+    top: -999px;
+    z-index: 100;
+    height: 24px;
+    transition: opacity 0.2s ease 0.2s;
+    background-color: var(--color-table-handle);
+    padding: 0 8px;
+    border-radius: 8px;
+    position: absolute;
+  }
+
+  milkdown-table-block .cell-handle[data-role="col-drag-handle"] {
+    transform: translateY(50%);
+  }
+
+  milkdown-table-block .cell-handle[data-role="row-drag-handle"] {
+    transform: translateX(50%);
+  }
+
+  milkdown-table-block .cell-handle[data-show="false"] {
+    opacity: 0;
+  }
+
+  milkdown-table-block .line-handle[data-show="false"] {
+    opacity: 0;
+  }
+
+  milkdown-table-block .handle:hover {
+    opacity: 1;
+  }
+
+  milkdown-table-block .cell-handle .button-group {
+    position: absolute;
+    height: 30px;
+    top: -32px;
+    display: flex;
+    transform: translateX(-50%);
+    left: 50%;
+    background-color: var(--color-table-button-group-background);
+    border: 1px solid var(--color-table-border);
+    border-radius: 4px;
+  }
+  milkdown-table-block .cell-handle .button-group[data-show="false"] {
+    display: none;
+  }
+  milkdown-table-block .cell-handle .button-group button {
+    padding-left: 8px;
+    padding-right: 8px;
+    width: max-content;
+  }
+  milkdown-table-block .cell-handle .button-group button:hover {
+    background-color: var(--color-table-button-hover-background);
+  }
+
+  milkdown-table-block .line-handle {
+    background-color: var(--color-table-handle);
+    transition: opacity 0.2s ease-in-out;
+  }
+  milkdown-table-block .line-handle[data-role="x-line-drag-handle"] {
+    height: 2px;
+  }
+  milkdown-table-block .line-handle[data-role="y-line-drag-handle"] {
+    width: 2px;
+  }
+
+  milkdown-table-block .line-handle .add-button  {
+    color: var(--color-table-handle);
+    border: 1px solid var(--color-table-handle);
+    padding: 0 4px;
+    border-radius: 8px;
+    width: max-content;
+  }
+
+  milkdown-table-block .line-handle[data-role="x-line-drag-handle"] .add-button  {
+    position: absolute;
+    transform: translateX(-100%);
+    top: -12px;
+    height: 24px;
+  }
+
+  milkdown-table-block .line-handle[data-role="y-line-drag-handle"] .add-button  {
+    position: absolute;
+    transform: translateX(-50%);
+    top: -24px;
+    height: 24px;
+  }
+
+  milkdown-table-block .line-handle[data-display-type="indicator"] .add-button  {
+    display: none;
+  }
+
+  milkdown-table-block .drag-preview {
+    position: absolute;
+    z-index: 100;
+    border: 1px solid #ccc;
+    opacity: 0.5;
+    display: flex;
+    flex-direction: column;
+  }
+
+  milkdown-table-block .drag-preview table {
+    margin: 0;
+  }
+
+  milkdown-table-block .drag-preview[data-show="false"] {
+    display: none;
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/components/typograph.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/components/typograph.css
@@ -1,0 +1,48 @@
+.milkdown {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-title);
+    font-weight: 400;
+    padding: 2px 0;
+  }
+
+  h1 {
+    font-size: 42px;
+    line-height: 50px;
+  }
+
+  h2 {
+    font-size: 36px;
+    line-height: 44px;
+  }
+
+  h3 {
+    font-size: 32px;
+    line-height: 40px;
+  }
+
+  h4 {
+    font-size: 28px;
+    line-height: 36px;
+  }
+
+  h5 {
+    font-size: 24px;
+    line-height: 32px;
+  }
+
+  h6 {
+    font-size: 18px;
+    line-height: 28px;
+  }
+
+  p {
+    font-size: 16px;
+    line-height: 24px;
+    padding: 4px 0;
+  }
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/prosemirror-tables.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/prosemirror-tables.css
@@ -1,0 +1,48 @@
+.ProseMirror .tableWrapper {
+  overflow-x: auto;
+}
+.ProseMirror table {
+  border-collapse: collapse;
+  table-layout: fixed;
+  width: 100%;
+  overflow: hidden;
+}
+.ProseMirror td,
+.ProseMirror th {
+  vertical-align: top;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.ProseMirror td:not([data-colwidth]):not(.column-resize-dragging),
+.ProseMirror th:not([data-colwidth]):not(.column-resize-dragging) {
+  /* if there's no explicit width set and the column is not being resized, set a default width */
+  min-width: var(--default-cell-min-width);
+}
+
+.ProseMirror .column-resize-handle {
+  position: absolute;
+  right: -2px;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  z-index: 20;
+  background-color: #adf;
+  pointer-events: none;
+}
+.ProseMirror.resize-cursor {
+  cursor: ew-resize;
+  cursor: col-resize;
+}
+/* Give selected cells a blue overlay */
+.ProseMirror .selectedCell:after {
+  z-index: 2;
+  position: absolute;
+  content: '';
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background: rgba(200, 200, 255, 0.4);
+  pointer-events: none;
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/prosemirror.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/prosemirror.css
@@ -1,0 +1,54 @@
+.ProseMirror {
+  position: relative;
+}
+
+.ProseMirror {
+  word-wrap: break-word;
+  white-space: pre-wrap;
+  white-space: break-spaces;
+  -webkit-font-variant-ligatures: none;
+  font-variant-ligatures: none;
+  font-feature-settings: "liga" 0; /* the above doesn't seem to work in Edge */
+}
+
+.ProseMirror pre {
+  white-space: pre-wrap;
+}
+
+.ProseMirror li {
+  position: relative;
+}
+
+.ProseMirror-hideselection *::selection { background: transparent; }
+.ProseMirror-hideselection *::-moz-selection { background: transparent; }
+.ProseMirror-hideselection { caret-color: transparent; }
+
+/* See https://github.com/ProseMirror/prosemirror/issues/1421#issuecomment-1759320191 */
+.ProseMirror [draggable][contenteditable=false] { user-select: text }
+
+.ProseMirror-selectednode {
+  outline: 2px solid #8cf;
+}
+
+/* Make sure li selections wrap around markers */
+
+li.ProseMirror-selectednode {
+  outline: none;
+}
+
+li.ProseMirror-selectednode:after {
+  content: "";
+  position: absolute;
+  left: -32px;
+  right: -2px; top: -2px; bottom: -2px;
+  border: 2px solid #8cf;
+  pointer-events: none;
+}
+
+/* Protect against generic img rules */
+
+img.ProseMirror-separator {
+  display: inline !important;
+  border: none !important;
+  margin: 0 !important;
+}

--- a/app/assets/tailwind/themes/_components/markdown-editor/variables.css
+++ b/app/assets/tailwind/themes/_components/markdown-editor/variables.css
@@ -1,0 +1,55 @@
+.milkdown {
+  --menu-bg: #2e3440;
+  --menu-border: #434b5e;
+  --menu-bg-hover: #81a1c11f;
+  --menu-text-color: white;
+  --menu-text-hover: #5e81ac;
+
+  --color-background: #fdfcff;
+  --color-on-background: #1b1c1d;
+  --color-surface: #f8f9ff;
+  --color-surface-low: #f2f3fa;
+  --color-on-surface: #191c20;
+  --color-on-surface-variant: #43474e;
+  --color-primary: #37618e;
+  --color-secondary: #d7e3f8;
+  --color-on-secondary: #101c2b;
+  --color-inverse: #2e3135;
+  --color-on-inverse: #eff0f7;
+  --color-error: #ba1a1a;
+  --color-hover: #eceef4;
+  --color-selected: #e1e2e8;
+
+  /* Code */
+  --color-code-text: #ba1a1a;
+  --color-code-background: #d8dae0;
+  --font-code:
+    'JetBrains Mono', Menlo, Monaco, 'Courier New', Courier, monospace;
+
+  /* Quote */
+  --color-quote-marker: #e1e2e8;
+
+  /* Divider */
+  --color-divider: #73777f;
+
+  /* List */
+  --color-list-checkbox-border: #6b7280;
+
+  /* Link */
+  --color-link-tooltip-background: rgb(239, 246, 255);
+  --color-link-tooltip-background-hover: rgb(96, 165, 250);
+
+  /* Table */
+  --color-table-border: #ccc;
+  --color-table-handle: #FFB4AB;
+  --color-table-button-group-background: #fff;
+  --color-table-button-hover-background: #f0f0f0;
+
+  --font-title: Rubik, Cambria, 'Times New Roman', Times, serif;
+  --font-default: Inter, Arial, Helvetica, sans-serif;
+
+  --shadow-1:
+    0px 1px 3px 1px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+  --shadow-2:
+    0px 2px 6px 2px rgba(0, 0, 0, 0.15), 0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+}

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -38,7 +38,8 @@
             } %>
       </div>
 
-      <%= render partial: 'issues/description_field', locals: { f:, issue: } %>
+      <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description" ) %>
+      <%= f.hidden_field :description, class: "js-issue-description" %>
 
       <div class="flex gap-2 justify-center">
         <a class="btn-cancel" data-action="click->modal#close">

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -74,7 +74,8 @@
               </div>
             <% end %>
 
-            <%= render partial: 'issues/description_field', locals: { f:, issue: } %>
+            <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description" ) %>
+            <%= f.hidden_field :description, class: "js-issue-description" %>
 
             <div class="flex gap-2 justify-end">
               <a class="btn-cancel" data-action="click->modal#close">

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -1,0 +1,76 @@
+import React from "react"
+
+import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react"
+import { Editor, rootCtx, defaultValueCtx } from "@milkdown/kit/core"
+
+import { listItemBlockComponent } from "@milkdown/kit/component/list-item-block"
+import { linkTooltipPlugin } from "@milkdown/kit/component/link-tooltip"
+import { tableBlock } from "@milkdown/kit/component/table-block"
+
+import { commonmark } from "@milkdown/kit/preset/commonmark"
+import { gfm } from "@milkdown/kit/preset/gfm"
+import { listener, listenerCtx } from "@milkdown/kit/plugin/listener"
+import { history } from "@milkdown/kit/plugin/history"
+import { clipboard } from "@milkdown/kit/plugin/clipboard"
+import { indent } from "@milkdown/kit/plugin/indent"
+import { imageBlockComponent } from '@milkdown/kit/component/image-block'
+import { trailing } from "@milkdown/kit/plugin/trailing"
+import { menu } from '@milkdown-lab/plugin-menu'
+
+import configureMenu from './MarkdownEditor/configure/menu'
+import configureLinkTooltip from './MarkdownEditor/configure/link-tooltip'
+import configureTableBlock from './MarkdownEditor/configure/table-block'
+import configureImageBlock from './MarkdownEditor/configure/image-block'
+
+function MilkdownEditor(props) {
+  useEditor((root) => {
+    return Editor.make()
+      .config((ctx) => {
+        ctx.set(rootCtx, root);
+
+        if (props.defaultValue) {
+          ctx.set(defaultValueCtx, props.defaultValue)
+        }
+
+        if (props.bindTarget) {
+          const target = document.querySelector(props.bindTarget)
+          ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
+            target.value = markdown
+          })
+        }
+      })
+      .config(configureMenu)
+      .config(configureLinkTooltip)
+      .config(configureTableBlock)
+      .config(configureImageBlock)
+      .use(listener)
+      .use(commonmark)
+      .use(gfm)
+      .use(clipboard)
+      .use(indent)
+      .use(menu)
+      .use(history)
+      .use(listItemBlockComponent)
+      .use(linkTooltipPlugin)
+      .use(tableBlock)
+      .use(trailing)
+      .use(imageBlockComponent)
+  }, [])
+
+  return (
+    <Milkdown />
+  )
+}
+
+
+function MarkdownEditor(props) {
+  return (
+    <React.StrictMode>
+      <MilkdownProvider>
+        <MilkdownEditor {...props}/>
+      </MilkdownProvider>
+    </React.StrictMode>
+  )
+}
+
+export default MarkdownEditor

--- a/frontend/components/MarkdownEditor/configure/image-block.js
+++ b/frontend/components/MarkdownEditor/configure/image-block.js
@@ -1,0 +1,20 @@
+import { html } from 'atomico'
+
+import { imageBlockConfig } from "@milkdown/kit/component/image-block"
+
+const customConfig = {
+  imageIcon: () => html`<i class="fa-solid fa-image"></i>`,
+  captionIcon: () => html`<i class="fa-solid fa-file-pen"></i>`,
+  uploadButton: () => html`<i class="fa-solid fa-file-arrow-up"></i>`,
+  confirmButton: () => html`<i class="fa-solid fa-check"></i>`,
+  captionPlaceholderText: "..."
+}
+
+export default function configure(ctx) {
+  ctx.update(imageBlockConfig.key, defaultConfig => {
+    return {
+      ...defaultConfig,
+      ...customConfig
+    }
+  })
+}

--- a/frontend/components/MarkdownEditor/configure/link-tooltip.js
+++ b/frontend/components/MarkdownEditor/configure/link-tooltip.js
@@ -1,0 +1,22 @@
+import { html } from 'atomico'
+
+import { configureLinkTooltip, linkTooltipConfig } from "@milkdown/kit/component/link-tooltip";
+
+const customConfig = {
+  linkIcon: () => html`<i class="fa-solid fa-link"></i>`,
+  editButton: () => html`<i class="fa-solid fa-pen"></i>`,
+  removeButton: () => html`<i class="fa-solid fa-trash-can"></i>`,
+  confirmButton: () => html`<i class="fa-solid fa-check"></i>`,
+  inputPlaceholder: "https://..."
+}
+
+export default function configure(ctx) {
+  configureLinkTooltip(ctx)
+
+  ctx.update(linkTooltipConfig.key, defaultConfig => {
+    return {
+      ...defaultConfig,
+      ...customConfig
+    }
+  })
+}

--- a/frontend/components/MarkdownEditor/configure/menu.js
+++ b/frontend/components/MarkdownEditor/configure/menu.js
@@ -1,0 +1,136 @@
+import { menu, menuConfigCtx } from '@milkdown-lab/plugin-menu'
+import { editorStateCtx, prosePluginsCtx, schemaCtx } from '@milkdown/core'
+
+function createButtonFor(command, options) {
+  return {
+    type: 'button',
+    content: createIconContent(command),
+    key: command,
+    ...options,
+  }
+}
+
+function createIconContent(command) {
+  const icon = document.createElement('i')
+  icon.className = classFor(command)
+  return icon
+}
+
+function classFor(command) {
+  switch(command) {
+    case 'ToggleStrong':
+      return 'fa-solid fa-bold'
+    case 'ToggleEmphasis':
+      return 'fa-solid fa-italic'
+    case 'ToggleStrikeThrough':
+      return 'fa-solid fa-strikethrough'
+    case 'WrapInBulletList':
+      return 'fa-solid fa-list-ul'
+    case 'WrapInOrderedList':
+      return 'fa-solid fa-list-ol'
+    case 'ToggleLink':
+      return 'fa-solid fa-link'
+    case 'InsertImage':
+      return 'fa-solid fa-image'
+    case 'InsertTable':
+      return 'fa-solid fa-table'
+    case 'CreateCodeBlock':
+      return 'fa-solid fa-code'
+    case 'WrapInBlockquote':
+      return 'fa-solid fa-quote-left'
+    case 'InsertHr':
+      return 'fa-solid fa-minus'
+  }
+}
+
+const hasMark = (state, type) => {
+  if (!type) return false
+  const { from, $from, to, empty } = state.selection
+  if (empty) return !!type.isInSet(state.storedMarks || $from.marks())
+
+  return state.doc.rangeHasMark(from, to, type)
+}
+
+const getUndoDepth = (ctx) => {
+  const historyKey = ctx.get(prosePluginsCtx).find(
+    (i) => i.key === 'history$',
+  )
+
+  const state = ctx.get(editorStateCtx)
+  const hist = historyKey?.getState(state)
+  return hist ? hist.done.eventCount : 0
+}
+
+const getRedoDepth = (ctx) => {
+  const historyKey = ctx.get(prosePluginsCtx).find(
+    (i) => i.key === 'history$',
+  )
+
+  const state = ctx.get(editorStateCtx)
+  const hist = historyKey?.getState(state)
+  return hist ? hist.undone.eventCount : 0
+}
+
+const menuItens = [
+  [
+    createButtonFor('ToggleStrong', {
+      active: (ctx) => {
+        const state = ctx.get(editorStateCtx)
+        const schema = ctx.get(schemaCtx)
+        return hasMark(state, schema.marks.strong)
+      },
+    }),
+    createButtonFor('ToggleEmphasis', {
+      active: (ctx) => {
+        const state = ctx.get(editorStateCtx)
+        const schema = ctx.get(schemaCtx)
+        return hasMark(state, schema.marks.emphasis)
+      },
+    }),
+    createButtonFor('ToggleStrikeThrough', {
+      active: (ctx) => {
+        const state = ctx.get(editorStateCtx)
+        const schema = ctx.get(schemaCtx)
+        return hasMark(state, schema.marks.strike_through)
+      },
+    }),
+  ],
+  [
+    {
+      type: 'select',
+      text: 'Heading',
+      options: [
+        { id: 1, content: 'Large Heading' },
+        { id: 2, content: 'Medium Heading' },
+        { id: 3, content: 'Small Heading' },
+        { id: 0, content: 'Plain Text' },
+      ],
+      onSelect: (id) => (!!id ? ['WrapInHeading', id] : 'TurnIntoText'),
+    },
+  ],
+  [
+    createButtonFor('WrapInBlockquote'),
+    createButtonFor('InsertHr'),
+    createButtonFor('WrapInBulletList'),
+    createButtonFor('WrapInOrderedList'),
+  ],
+  [
+    createButtonFor('ToggleLink', {
+      key: ['ToggleLink', { href: '' }]
+    }),
+    // Comment this until we implement actual image drop
+    //createButtonFor('InsertImage'),
+    createButtonFor('InsertTable'),
+    createButtonFor('CreateCodeBlock'),
+  ],
+]
+
+
+const config = {
+  attributes: { class: 'milkdown-menu' },
+  items: menuItens
+}
+
+export default function configure(ctx) {
+  ctx.set(menuConfigCtx.key, config)
+}

--- a/frontend/components/MarkdownEditor/configure/table-block.js
+++ b/frontend/components/MarkdownEditor/configure/table-block.js
@@ -1,0 +1,37 @@
+import { html } from "atomico"
+
+import { tableBlockConfig } from "@milkdown/kit/component/table-block"
+
+const customConfig = {
+  renderButton: (renderType) => {
+    switch (renderType) {
+      case "add_row":
+        return html`<i class="fa-solid fa-plus"></i>`
+      case "add_col":
+        return html`<i class="fa-solid fa-plus"></i>`
+      case "delete_row":
+        return html`<i class="fa-solid fa-trash-can"></i>`
+      case "delete_col":
+        return html`<i class="fa-solid fa-trash-can"></i>`
+      case "align_col_left":
+        return html`<i class="fa-solid fa-align-left"></i>`
+      case "align_col_center":
+        return html`<i class="fa-solid fa-align-center"></i>`
+      case "align_col_right":
+        return html`<i class="fa-solid fa-align-right"></i>`
+      case "col_drag_handle":
+        return html`<i class="fa-solid fa-grip-lines"></i>`
+      case "row_drag_handle":
+        return html`<i class="fa-solid fa-grip-lines-vertical"></i>`
+    }
+  }
+}
+
+export default function configure(ctx) {
+  ctx.update(tableBlockConfig.key, defaultConfig => {
+    return {
+      ...defaultConfig,
+      ...customConfig
+    }
+  })
+}

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -129,7 +129,7 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     expect(Issue.last.title).to eq("My issue")
     expect(Issue.last.labels_list).to eq([ "Development" ])
-    expect(Issue.last.description).to eq("My description")
+    expect(Issue.last.description).to include("My description")
   end
 
   specify "I can update issues" do

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -124,7 +124,7 @@ describe 'As a user, I want to manage my project using a kanban view' do
 
     issue = Issue.last
     expect(issue.title).to eq("Updated title")
-    expect(issue.description).to eq("Issue description appending description")
+    expect(issue.description).to include("Issue description appending description")
 
     within dom_id(grouping) do
       expect(page).to have_content("Updated title")

--- a/spec/support/helpers/markdown_editor.rb
+++ b/spec/support/helpers/markdown_editor.rb
@@ -1,19 +1,13 @@
 module MarkdownEditorHelper
   def write_in_md_editor_field(text)
-    within ".CodeMirror" do
-      # Click makes CodeMirror element active:
-      current_scope.click
-
-      # Find the hidden textarea:
-      field = current_scope.find("textarea", visible: false)
-
-      # Mimic user typing the text:
-      field.send_keys text
+    within markdown_editor_selector do
+      current_scope.send_keys text
+      sleep(0.5)
     end
   end
 
   def markdown_editor_selector
-    ".CodeMirror-code"
+    ".ProseMirror"
   end
 end
 


### PR DESCRIPTION
This PR brings the new markdown editor with more robust and future proof features.

This editor It's already integrated on the PRO Edition and It is configured with:

- Formatting support (Bold, italic, strikethrough)
- Headings
- Coding blocks
- Support for undo and redo commands (CTRL + Z & CTRL + SHIFT + Z)
- Links
- Quotes
- Divisor line
- Lists (Ordered, unordered)
- Checklists
- Table
- And even images (External ones, directly upload doesn't work yet...)

