### PR TITLE
Adds focus space step to guided tour

### DIFF
--- a/app/javascript/app-tours/projects_tours.en.js
+++ b/app/javascript/app-tours/projects_tours.en.js
@@ -11,10 +11,10 @@ const projectsIndexTour = [
 
   },
   {
-    element: ".tour--add-project",
+    element: ".tour--open-focus-app-button",
     popover: {
-      title: "Create New Project",
-      description: "You can create a new project by clicking here."
+      title: "Focus Space",
+      description: "This is your focus space. Here you can concentrate on your current task without distractions."
     }
   },
   {

--- a/app/javascript/app-tours/projects_tours.pt-BR.js
+++ b/app/javascript/app-tours/projects_tours.pt-BR.js
@@ -8,13 +8,12 @@ const projectsIndexTour = [
       title: "Guia de Funcionalidades",
       description: "Dica rápida: Você pode clicar aqui para ver um guia de nossas funcionalidades."
     },
-
   },
   {
-    element: ".tour--add-project",
+    element: ".tour--open-focus-app-button",
     popover: {
-      title: "Criar Novo Projeto",
-      description: "Você pode criar um novo projeto clicando aqui."
+      title: "Espaço de Foco",
+      description: "Este é o seu espaço de foco. Aqui você pode se concentrar nas suas tarefas sem distrações."
     }
   },
   {
@@ -40,7 +39,7 @@ const projectsIndexTour = [
   {
     element: ".tour--workflow-board",
     popover: {
-      title: "Quadro de Fluxo",
+      title: "Quadro de trabalho",
       description: "Veja seu quadro de trabalho."
     }
   },

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -11,7 +11,7 @@
   </h2>
   <%= link_to "#{t('actions.create')} #{Project.model_name.human.downcase}",
       new_project_path,
-      class: "btn-primary btn-xl tour--add-project",
+      class: "btn-primary btn-xl",
       data: { turbo_frame: 'project_form' } %>
 </div>
 

--- a/frontend/components/FocusApp.js
+++ b/frontend/components/FocusApp.js
@@ -19,7 +19,7 @@ const FocusApp = ({ }) => {
         onPomodoroStop={() => setIsPomodoroRunning(false)}
         onHide={() => setIsShowing(false)} />
 
-      <div className="focus-space-access-buttons">
+      <div className="focus-space-access-buttons tour--open-focus-app-button">
         <button className={`open-space-button ${isShowing ? 'close' : 'open'}`} onClick={() => setIsShowing(!isShowing)}>
           <FontAwesomeIcon icon={isShowing ? faXmark : faWindowRestore} />
           <span className='sound-playing-icon'>

--- a/spec/features/app_tour_spec.rb
+++ b/spec/features/app_tour_spec.rb
@@ -54,7 +54,7 @@ describe 'As a user, I can follow the tours' do
 
     should_have_tour_popover("Guided Tour", "Quick tip:")
     next_tour_step
-    should_have_tour_popover("Create New Project")
+    should_have_tour_popover("Focus Space")
   end
 
   specify "I can start the issues list tour" do

--- a/spec/features/app_tour_spec.rb
+++ b/spec/features/app_tour_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'As a user, I can follow the tourd tours' do
+describe 'As a user, I can follow the tours' do
   let!(:user) { FactoryBot.create(:user) }
 
   before(:each) do


### PR DESCRIPTION
This PR: 

- Removes the "Add project" explanation step
- Adds "Focus App" explanation step
- Fixes wrong pt-br translations