### PR TITLE
chore: disables turbo cache

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <meta name="tour-language" content="<%= I18n.locale %>">
+    <meta name="turbo-cache-control" content="no-cache">
 
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/app/views/projects/_navigation_header.html.erb
+++ b/app/views/projects/_navigation_header.html.erb
@@ -47,7 +47,7 @@
     ].each do |tab|
 
     tab[:options][:class] = "flex items-center gap-1 px-2 pb-2 whitespace-nowrap hover:text-primary-500"
-    tab[:options][:data] = { turbo_frame: "_top", turbo_prefetch: "false", turbo_preload: "false" }
+    tab[:options][:data] = { turbo_frame: "_top", turbo_prefetch: "false" }
     if tab[:is_selected]
       tab[:options][:class] += "border-b-2 border-primary-500 text-primary-500"
     end


### PR DESCRIPTION
This PR disables turbo cache for the entire application. 

https://turbo.hotwired.dev/handbook/building#opting-out-of-caching

Previously, we were noticing page flickers when navigating to pages with a slower response time. This was due to the old page being rendered from the browser cache and then the new page being rendered from the server after the response came in.

This PR disables the cache for all turbo pages to avoid any future problems. 

It also removes "turbo-preload" from the navigation header. It's already disabled by default. 

# Reproducing the problem
The test was made by simulating latency with

```ruby

  before_action -> {
    puts "sleeping"
    sleep 0.6
    puts "done sleeping"
  }

```

# Before: with cache


https://github.com/user-attachments/assets/ac8fb770-aaa1-42fd-bcd8-c7489df08a09

# After: no cache

https://github.com/user-attachments/assets/0f75b854-87a1-4bbb-aae8-c5292a9edad7


