### PR TITLE
chore: manually setting grouping position during template usage

### DIFF
--- a/app/services/project/templatable/template_applier.rb
+++ b/app/services/project/templatable/template_applier.rb
@@ -22,8 +22,8 @@ class Project::Templatable::TemplateApplier
   end
 
   def create_groupings
-    template.groupings.each do |grouping_name|
-      @board.groupings.create!(title: grouping_name)
+    template.groupings.each_with_index do |grouping_name, index|
+      @board.groupings.create!(title: grouping_name, position: index + 1)
     end
   end
 


### PR DESCRIPTION
The logic without the position being manually set was causing delay for the position to be correctly updated and if I created a project using a template and instantly go to the workflow board the columns would take a while to be ordered. 