### PR TITLE
Better ui and ux for focus space

### DIFF
--- a/app/assets/tailwind/themes/_components/focus-app/focus-app.css
+++ b/app/assets/tailwind/themes/_components/focus-app/focus-app.css
@@ -54,7 +54,7 @@
 
   .sound-playing-icon {
     @apply rounded-full text-primary-700/50;
-    display: none;
+    display: block;
     font-size: 12px;
     position: absolute;
     bottom: -4px;
@@ -63,23 +63,11 @@
 
   .pomodoro-running-icon {
     @apply rounded-full text-primary-700/50;
-    display: none;
+    display: block;
     font-size: 12px;
     position: absolute;
     top: -4px;
     left: 4px;
-  }
-
-  &.playing:not(.space-showing) {
-    .sound-playing-icon {
-      display: block;
-    }
-  }
-
-  &.pomodoro-running:not(.space-showing) {
-    .pomodoro-running-icon {
-      display: block;
-    }
   }
 
   .sound-wave .Line_1 {

--- a/app/assets/tailwind/themes/_components/focus-app/focus-app.css
+++ b/app/assets/tailwind/themes/_components/focus-app/focus-app.css
@@ -10,6 +10,12 @@
       @apply text-xl rounded-md p-4 border;
 
       transition: all 0.2s ease-in-out;
+
+      .ping-notification {
+        @apply absolute flex size-3;
+        top: -4px;
+        left: -4px;
+      }
     }
 
     .open-space-button.open {
@@ -108,7 +114,6 @@
     animation-delay: 1.35s;
   }
 }
-
 
 @keyframes float {
   0% {

--- a/frontend/components/FocusApp.js
+++ b/frontend/components/FocusApp.js
@@ -11,12 +11,12 @@ const FocusApp = ({ }) => {
   const [pomodoroState, setPomodoroState] = useState(POMODORO_STATE.STOPPED)
 
   const handlePomodoroStateChange = (newState) => {
-    console.log("newState", newState)
     setPomodoroState(newState)
   }
 
   return (
     <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''}`}>
+
       <FocusSpace isFocusSpaceShowing={isFocusSpaceShowing}
         onPlayStart={() => setHasSoundPlaying(true)}
         onPlayToggle={() => setHasSoundPlaying(false)}
@@ -27,16 +27,29 @@ const FocusApp = ({ }) => {
 
         <button className={`tour--open-focus-app-button open-space-button ${isFocusSpaceShowing ? 'close' : 'open'}`} onClick={() => setIsFocusSpaceShowing(!isFocusSpaceShowing)}>
           <FontAwesomeIcon icon={isFocusSpaceShowing ? faXmark : faWindowRestore} />
-          {hasSoundPlaying && (
-            <span className='sound-playing-icon'>
-              <FontAwesomeIcon icon={faVolumeHigh} />
-            </span>
-          )}
 
-          {(pomodoroState === POMODORO_STATE.RUNNING || pomodoroState === POMODORO_STATE.PAUSED) && (
-            <span className='pomodoro-running-icon'>
-              <FontAwesomeIcon icon={faHourglassHalf} />
-            </span>
+
+          {!isFocusSpaceShowing && (
+            <>
+              {(pomodoroState === POMODORO_STATE.FINISHED) && (
+                <span className="ping-notification">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary-600 opacity-75"></span>
+                  <span className="relative inline-flex size-3 rounded-full bg-primary-700"></span>
+                </span>
+              )}
+
+              {hasSoundPlaying && (
+                <span className='sound-playing-icon'>
+                  <FontAwesomeIcon icon={faVolumeHigh} />
+                </span>
+              )}
+
+              {(pomodoroState === POMODORO_STATE.RUNNING || pomodoroState === POMODORO_STATE.PAUSED) && (
+                <span className='pomodoro-running-icon'>
+                  <FontAwesomeIcon icon={faHourglassHalf} />
+                </span>
+              )}
+            </>
           )}
         </button>
 

--- a/frontend/components/FocusApp.js
+++ b/frontend/components/FocusApp.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import FocusSpace from "./FocusSpace"
-
+import { POMODORO_STATE } from "./FocusSpace/PomodoroTimer/PomodoroTimer"
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faXmark, faWindowRestore, faVolumeHigh, faHourglassHalf } from '@fortawesome/free-solid-svg-icons'
 
@@ -8,15 +8,19 @@ const FocusApp = ({ }) => {
 
   const [isFocusSpaceShowing, setIsFocusSpaceShowing] = useState(false)
   const [hasSoundPlaying, setHasSoundPlaying] = useState(false)
-  const [isPomodoroRunning, setIsPomodoroRunning] = useState(false)
+  const [pomodoroState, setPomodoroState] = useState(POMODORO_STATE.STOPPED)
+
+  const handlePomodoroStateChange = (newState) => {
+    console.log("newState", newState)
+    setPomodoroState(newState)
+  }
 
   return (
-    <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''} ${hasSoundPlaying ? 'playing' : ''} ${isPomodoroRunning ? 'pomodoro-running' : ''}`}>
+    <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''} ${hasSoundPlaying ? 'playing' : ''} ${pomodoroState === POMODORO_STATE.RUNNING ? 'pomodoro-running' : ''}`}>
       <FocusSpace isFocusSpaceShowing={isFocusSpaceShowing}
         onPlayStart={() => setHasSoundPlaying(true)}
         onPlayToggle={() => setHasSoundPlaying(false)}
-        onPomodoroStart={() => setIsPomodoroRunning(true)}
-        onPomodoroStop={() => setIsPomodoroRunning(false)}
+        onPomodoroStateChange={handlePomodoroStateChange}
         onHide={() => setIsFocusSpaceShowing(false)} />
 
       <div className="focus-space-access-buttons">

--- a/frontend/components/FocusApp.js
+++ b/frontend/components/FocusApp.js
@@ -6,23 +6,23 @@ import { faXmark, faWindowRestore, faVolumeHigh, faHourglassHalf } from '@fortaw
 
 const FocusApp = ({ }) => {
 
-  const [isShowing, setIsShowing] = useState(false)
+  const [isFocusSpaceShowing, setIsFocusSpaceShowing] = useState(false)
   const [hasSoundPlaying, setHasSoundPlaying] = useState(false)
   const [isPomodoroRunning, setIsPomodoroRunning] = useState(false)
 
   return (
-    <div className={`focus-app ${isShowing ? 'space-showing' : ''} ${hasSoundPlaying ? 'playing' : ''} ${isPomodoroRunning ? 'pomodoro-running' : ''}`}>
-      <FocusSpace isShowing={isShowing}
+    <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''} ${hasSoundPlaying ? 'playing' : ''} ${isPomodoroRunning ? 'pomodoro-running' : ''}`}>
+      <FocusSpace isFocusSpaceShowing={isFocusSpaceShowing}
         onPlayStart={() => setHasSoundPlaying(true)}
         onPlayToggle={() => setHasSoundPlaying(false)}
         onPomodoroStart={() => setIsPomodoroRunning(true)}
         onPomodoroStop={() => setIsPomodoroRunning(false)}
-        onHide={() => setIsShowing(false)} />
+        onHide={() => setIsFocusSpaceShowing(false)} />
 
       <div className="focus-space-access-buttons">
 
-        <button className={`tour--open-focus-app-button open-space-button ${isShowing ? 'close' : 'open'}`} onClick={() => setIsShowing(!isShowing)}>
-          <FontAwesomeIcon icon={isShowing ? faXmark : faWindowRestore} />
+        <button className={`tour--open-focus-app-button open-space-button ${isFocusSpaceShowing ? 'close' : 'open'}`} onClick={() => setIsFocusSpaceShowing(!isFocusSpaceShowing)}>
+          <FontAwesomeIcon icon={isFocusSpaceShowing ? faXmark : faWindowRestore} />
           <span className='sound-playing-icon'>
             <FontAwesomeIcon icon={faVolumeHigh} />
           </span>

--- a/frontend/components/FocusApp.js
+++ b/frontend/components/FocusApp.js
@@ -16,7 +16,7 @@ const FocusApp = ({ }) => {
   }
 
   return (
-    <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''} ${hasSoundPlaying ? 'playing' : ''} ${pomodoroState === POMODORO_STATE.RUNNING ? 'pomodoro-running' : ''}`}>
+    <div className={`focus-app ${isFocusSpaceShowing ? 'space-showing' : ''}`}>
       <FocusSpace isFocusSpaceShowing={isFocusSpaceShowing}
         onPlayStart={() => setHasSoundPlaying(true)}
         onPlayToggle={() => setHasSoundPlaying(false)}
@@ -27,13 +27,17 @@ const FocusApp = ({ }) => {
 
         <button className={`tour--open-focus-app-button open-space-button ${isFocusSpaceShowing ? 'close' : 'open'}`} onClick={() => setIsFocusSpaceShowing(!isFocusSpaceShowing)}>
           <FontAwesomeIcon icon={isFocusSpaceShowing ? faXmark : faWindowRestore} />
-          <span className='sound-playing-icon'>
-            <FontAwesomeIcon icon={faVolumeHigh} />
-          </span>
+          {hasSoundPlaying && (
+            <span className='sound-playing-icon'>
+              <FontAwesomeIcon icon={faVolumeHigh} />
+            </span>
+          )}
 
-          <span className='pomodoro-running-icon'>
-            <FontAwesomeIcon icon={faHourglassHalf} />
-          </span>
+          {(pomodoroState === POMODORO_STATE.RUNNING || pomodoroState === POMODORO_STATE.PAUSED) && (
+            <span className='pomodoro-running-icon'>
+              <FontAwesomeIcon icon={faHourglassHalf} />
+            </span>
+          )}
         </button>
 
       </div>

--- a/frontend/components/FocusSpace/FocusSpace.js
+++ b/frontend/components/FocusSpace/FocusSpace.js
@@ -2,7 +2,7 @@ import React, { useState } from "react"
 import AmbientSoundsPlayer from "./AmbientSoundsPlayer"
 import PomodoroTimer from "./PomodoroTimer"
 
-const FocusSpace = ({ isShowing, onHide, onPlayStart, onPlayToggle, onPomodoroStart, onPomodoroStop }) => {
+const FocusSpace = ({ isShowing, onHide, onPlayStart, onPlayToggle, onPomodoroStateChange }) => {
 
   const handleClickOutside = (e) => {
     if (e.target === e.currentTarget) {
@@ -15,7 +15,7 @@ const FocusSpace = ({ isShowing, onHide, onPlayStart, onPlayToggle, onPomodoroSt
       <div className={`focus-space`} onClick={handleClickOutside}>
 
         <div className="flex items-center justify-center">
-          <PomodoroTimer onStart={onPomodoroStart} onStop={onPomodoroStop} />
+          <PomodoroTimer onStateChange={onPomodoroStateChange} />
         </div>
         <div className="flex items-center justify-center">
           <AmbientSoundsPlayer onPlay={onPlayStart} onStop={onPlayToggle} />


### PR DESCRIPTION
This PR:

- Refactors pomodoro timer logic to be more state machine like
- Changes pomodoro events props to have only one `onStateChange` prop

On Focus Space button:
- Adds a ping notification when a timer has finished
- Keeps pomodoro icon showing even if the timer is pause (it's not the sabe as being stopped)