### PR TITLE
chore: change columns render order in board visualization

### DIFF
--- a/app/views/visualizations/show.html.erb
+++ b/app/views/visualizations/show.html.erb
@@ -34,7 +34,7 @@
             data-visualization--board-signed-groupings-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             data-visualization--board-signed-allocations-stream-token-value="<%= signed_stream_token({action: 'update', visualization_id: @visualization.id}) %>"
             >
-          <%= render partial: 'visualizations/column', collection: @visualization.groupings, as: :grouping, locals: {
+          <%= render partial: 'visualizations/column', collection: @visualization.groupings.sort_by(&:position), as: :grouping, locals: {
             visualization: @visualization,
             open_issue:  @open_issue
           } %>


### PR DESCRIPTION
When navigating to the board the request is being prefetched and the cached content is rendered after clicking the Workflow Link. 

This can lead to a quick "column reordening" because the view rendered by rails wasn't rendering columns following their position and, after the cached being rendered in the browser, it would take a few ms for the sortable library to correctly reorder the columns. 

With this change, this doesn't happen anymore.


# Supressing broadcasts

The messages were being sent with lag so if the user quickly navigate to the board, the browser would receive the messages from the create action and mess with the board. 

The suppress methods must be called from the outside of any transaction so we're leaving it in the controller. We can decide to move it later to some model callback. 