### PR TITLE
Fix: Modal X position broke after modal changes

### DIFF
--- a/app/helpers/application_helper/modal.rb
+++ b/app/helpers/application_helper/modal.rb
@@ -19,8 +19,12 @@ module Modal
     }.deep_merge(container_options)
 
     inner_container_options = {
-      class: "max-h-screen w-full max-w-lg relative"
-    }.deep_merge(inner_container_options)
+      class: "max-h-screen w-full max-w-lg"
+    }.deep_merge(inner_container_options).tap do |options|
+      # The inner container must always be relative, no matter if we override the
+      # default options. So we need to add it if it is not there yet.
+      options[:class] += " relative" unless options[:class].include? "relative"
+    end
 
     content_tag(:div, wrapper_options) do
       content_tag(:div, container_options) do


### PR DESCRIPTION
## Why?

During development of the latest features, we end up changing the modal styles for each page/component, so it would better fit the context and intention.

However, we accidentally remove the relative CSS class for modals with custom styles/sizes. And that causes the X button of some modals to appear on the top-right corner.

## Before

![image](https://github.com/user-attachments/assets/d588623a-ee97-433c-bee9-4359d33e0b9e)

## After

![image](https://github.com/user-attachments/assets/3b8f73f7-0371-488b-8725-b615adbc9291)
