### PR TITLE
chore: Project quick access from sidebar

### DIFF
--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -33,22 +33,10 @@
 
                </div>
             </div>
+            <%= render partial: 'layouts/_sidebar/projects_menu' %>
 
             <%= render partial: 'layouts/_sidebar/menu_group', locals: {
                menu_items: [
-                  {
-                    text: t('.menu.projects'),
-                    icon: icon_for(:projects),
-                    url: projects_path,
-                    main_controller: :projects,
-                    hover_menu: [{ text: t('.menu.all_projects'), url: projects_path }] + Project.order(name: :asc).all.map { |p|
-                      {
-                        text: p.name,
-                        url: visualization_path(p.default_visualization)
-                      }
-                    }
-
-                  },
                   {
                     text: t('.menu.timesheet'),
                     icon: icon_for(:time_entries),

--- a/app/views/layouts/_sidebar/_projects_menu.html.erb
+++ b/app/views/layouts/_sidebar/_projects_menu.html.erb
@@ -1,10 +1,18 @@
-<div class=" hover:border-r-2 border-primary-700 hover:bg-background-100 truncate transition duration-150 text-readable-content-500">
-  <%= link_to projects_path,
-      class: "flex items-center text-lg px-8 py-4 md:sidebar-expanded:pb-2" do %>
+<div class="text-readable-content-500">
+  <div class="flex items-stretch pl-8">
+    <%= link_to projects_path,
+        class: "flex items-center grow text-lg py-4 md:sidebar-expanded:pb-2" do %>
 
-    <%= icon_for(:projects) %>
-    <span class="text-sm font-medium ml-4 md:hidden md:sidebar-expanded:block "><%= t('.projects') %></span>
-  <% end %>
+      <%= icon_for(:projects) %>
+      <span class="text-sm font-medium ml-4 md:hidden md:sidebar-expanded:block "><%= t('.projects') %></span>
+    <% end %>
+
+    <%= link_to new_project_path,
+        class: "items-center justify-center flex gap-2 px-4 pt-4 pb-2 text-xs hover:font-bold hover:text-primary-800" do %>
+      <i class="fa fa-plus"></i>
+      <%= t('actions.add') %>
+    <% end %>
+  </div>
 
   <div class="max-h-[300px] overflow-y-auto px-8 md:hidden md:sidebar-expanded:block pb-4">
     <%= link_to projects_path,

--- a/app/views/layouts/_sidebar/_projects_menu.html.erb
+++ b/app/views/layouts/_sidebar/_projects_menu.html.erb
@@ -1,0 +1,37 @@
+<ul class="flex flex-col">
+  <li class="relative group">
+    <%
+      project_link_classes = "block px-8 py-4 hover:border-r-2 border-primary-700 hover:bg-background-100 hover:text-primary-700 truncate transition duration-150"
+
+      if controller_name.to_sym == :projects.to_sym
+        project_link_classes += " border-r-2 text-primary-700 bg-background-100"
+      else
+        project_link_classes += " text-readable-content-500"
+      end
+
+    %>
+    <%= link_to projects_path, class: project_link_classes do %>
+      <div class="flex  flex-col justify-between gap-2">
+        <div class="flex items-center text-lg">
+
+          <span class=" group-hover:text-primary-700">
+            <%= icon_for(:projects) %>
+          </span>
+          <span class="group-hover:text-primary-700 group-hover:font-bold group-active:text-primary-700 text-sm font-medium ml-4 md:hidden md:sidebar-expanded:block"><%= t('.menu.projects') %></span>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="hidden group-hover:flex w-max flex-col">
+      <%= link_to t('.menu.all_projects'), projects_path,
+          class: "text-sm font-medium text-readable-content-500 p-4 pr-8 hover:bg-primary-300 hover:text-primary-800" %>
+      <%  Project.active.order(name: :asc).all.each do |project| %>
+        <%= link_to project.name, visualization_path(project.default_visualization),
+          class: "text-sm font-medium text-readable-content-500 p-4 pr-8 hover:bg-primary-300 hover:text-primary-800" %>
+      <% end %>
+
+    </div>
+
+  </li>
+
+</ul>

--- a/app/views/layouts/_sidebar/_projects_menu.html.erb
+++ b/app/views/layouts/_sidebar/_projects_menu.html.erb
@@ -1,37 +1,21 @@
-<ul class="flex flex-col">
-  <li class="relative group">
-    <%
-      project_link_classes = "block px-8 py-4 hover:border-r-2 border-primary-700 hover:bg-background-100 hover:text-primary-700 truncate transition duration-150"
+<div class=" hover:border-r-2 border-primary-700 hover:bg-background-100 truncate transition duration-150 text-readable-content-500">
+  <%= link_to projects_path,
+      class: "flex items-center text-lg px-8 py-4 md:sidebar-expanded:pb-2" do %>
 
-      if controller_name.to_sym == :projects.to_sym
-        project_link_classes += " border-r-2 text-primary-700 bg-background-100"
-      else
-        project_link_classes += " text-readable-content-500"
-      end
+    <%= icon_for(:projects) %>
+    <span class="text-sm font-medium ml-4 md:hidden md:sidebar-expanded:block "><%= t('.projects') %></span>
+  <% end %>
 
-    %>
-    <%= link_to projects_path, class: project_link_classes do %>
-      <div class="flex  flex-col justify-between gap-2">
-        <div class="flex items-center text-lg">
+  <div class="max-h-[300px] overflow-y-auto px-8 md:hidden md:sidebar-expanded:block pb-4">
+    <%= link_to projects_path,
+        class: "text-xs py-1.5 flex gap-2 items-center font-normal grow text-readable-content-500 hover:font-semibold hover:text-primary-800" do %>
 
-          <span class=" group-hover:text-primary-700">
-            <%= icon_for(:projects) %>
-          </span>
-          <span class="group-hover:text-primary-700 group-hover:font-bold group-active:text-primary-700 text-sm font-medium ml-4 md:hidden md:sidebar-expanded:block"><%= t('.menu.projects') %></span>
-        </div>
-      </div>
+      <%= t('.list_all_projects') %>
+    <% end %>
+    <%  Project.active.order(name: :asc).all.each do |project| %>
+      <%= link_to project.name, visualization_path(project.default_visualization),
+        class: "block text-xs py-1.5 grow font-normal text-readable-content-500 hover:font-semibold hover:text-primary-800 truncate" %>
     <% end %>
 
-    <div class="hidden group-hover:flex w-max flex-col">
-      <%= link_to t('.menu.all_projects'), projects_path,
-          class: "text-sm font-medium text-readable-content-500 p-4 pr-8 hover:bg-primary-300 hover:text-primary-800" %>
-      <%  Project.active.order(name: :asc).all.each do |project| %>
-        <%= link_to project.name, visualization_path(project.default_visualization),
-          class: "text-sm font-medium text-readable-content-500 p-4 pr-8 hover:bg-primary-300 hover:text-primary-800" %>
-      <% end %>
-
-    </div>
-
-  </li>
-
-</ul>
+  </div>
+</div>

--- a/config/locales/application.layout.en.yml
+++ b/config/locales/application.layout.en.yml
@@ -50,7 +50,8 @@ en:
       edit_profile: "Edit profile"
       profile_options: "Profile & Settings"
       menu:
-        projects: 'Projects'
-        all_projects: 'All projects'
         timesheet: 'Timesheet'
         total_time_report: 'Time reports'
+      projects_menu:
+        list_all_projects: 'List all projects'
+        projects: 'Projects'

--- a/config/locales/application.layout.pt-BR.yml
+++ b/config/locales/application.layout.pt-BR.yml
@@ -51,7 +51,8 @@ pt-BR:
       edit_profile: "Editar perfil"
       profile_options: "Perfil e configurações"
       menu:
-        projects: 'Projetos'
-        all_projects: 'Todos os projetos'
         timesheet: 'Registros de Tempo'
         total_time_report: 'Relatórios de Tempo'
+      projects_menu:
+        list_all_projects: 'Listar todos os projetos'
+        projects: 'Projetos'

--- a/spec/views/layouts/_sidebar/projects_menu.html.erb_spec.rb
+++ b/spec/views/layouts/_sidebar/projects_menu.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe "layouts/_sidebar/_projects_menu.html.erb" do
+  let!(:project1) { create(:project, name: 'Project 1') }
+  let!(:project2) { create(:project, name: 'Project 2') }
+  let!(:project3) { create(:project, :archived, name: 'Project 3') }
+
+  it "displays all active projects" do
+    render
+
+    expect(rendered).to have_link('Project 1', href: visualization_path(project1.default_visualization))
+    expect(rendered).to have_link('Project 2', href: visualization_path(project2.default_visualization))
+
+    expect(rendered).not_to have_text('Project 3')
+  end
+end


### PR DESCRIPTION
As our workspace grows with multiple projects, it's nice to have a quick way to take a look at the list of projects and add a new one.

# Changes 

So, this PR updates the sidebar to: 

- Always list the workspace projects (alphabetically and only active ones)
- Have an "Add project" button
- Have a "List all projects" link

# Details

- A new partial `_projects_menu.html.erb` was created to render the projects menu in the sidebar. Not worth trying to reuse the menu group (actually it may be worth deleting it)
- There's a max-height (300px) set for the list. After that, the browser scrollbar appears

<img width="892" alt="image" src="https://github.com/user-attachments/assets/aa82d94d-15db-4a22-b6fd-67ed7254c303" />

<img width="394" alt="image" src="https://github.com/user-attachments/assets/dbccb3c0-4d25-4f52-864e-805d85896e30" />

