### PR TITLE
Downgrade selenium/standalone-chrome image

### DIFF
--- a/docker-compose.dev.example.yml
+++ b/docker-compose.dev.example.yml
@@ -45,7 +45,7 @@ services:
     command: "bin/shakapacker -w"
 
   selenium:
-    image: selenium/standalone-chrome:latest
+    image: selenium/standalone-chrome:131.0-20250414
     platform: linux/amd64
     environment:
       - SE_VNC_NO_PASSWORD=true


### PR DESCRIPTION
Current chromium (134) is causing a lot of intermittent failures in our specs. So I'm punishing it by downgrading it to a version that (hopefully) won't break things.

For reference:
https://github.com/teamcapybara/capybara/issues/2800
https://github.com/teamcapybara/capybara/issues/2796
https://issues.chromium.org/issues/402796660