### PR TITLE
Sidebar menu enhancements

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -3,7 +3,7 @@
   <div class="flex items-center justify-between px-4 sm:px-6 lg:px-8 h-16">
 
     <div class="flex gap-4">
-      <button class="text-readable-content-500 hover:text-readable-content-600 lg:hidden" data-action="click->sidebar#open" aria-controls="sidebar" aria-expanded="false">
+      <button class="text-readable-content-500 hover:text-readable-content-600 lg:hidden" data-action="click->sidebar#toggleSidebarMenu" aria-controls="sidebar" aria-expanded="false">
         <span class="sr-only">Open sidebar</span>
         <svg class="w-6 h-6 fill-readable-content-500" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <rect x="4" y="5" width="16" height="2"></rect>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -6,7 +6,7 @@
       class="flex border-r border-background-200 bg-background-menu lg:!flex flex-col justify-stretch absolute left-0 top-0 lg:static lg:left-auto lg:top-auto lg:translate-x-0 h-[100dvh]  w-64 lg:w-20 lg:sidebar-expanded:!w-64 shrink-0 transition-all duration-200 ease-in-out -translate-x-64 shadow-sm">
       <div class="flex grow flex-col overflow-visible">
          <div class="h-16 mb-4 md:mb-0 lg:sidebar-expanded:mb-8 relative cpy-sidebar-login-data">
-            <button data-action="click->sidebar#close" style="right: 15px; top: calc(50% - 16px);" class="absolute z-20 md:hidden text-2xl text-readable-content-400 opacity-80 hover:text-readable-content-700">
+            <button data-action="click->sidebar#closeAsMenu" style="right: 15px; top: calc(50% - 16px);" class="absolute z-20 md:hidden text-2xl text-readable-content-400 opacity-80 hover:text-readable-content-700">
                <i class="fa fa-xmark"></i>
             </button>
             <div class="flex justify-center items-center p-4 hidden sidebar-expanded:block">
@@ -26,11 +26,18 @@
                </div>
                <div class="hidden lg:block justify-end">
 
-                  <button data-action="click->sidebar#toogleSidebarExpanded" class="text-readable-content-400 hover:text-readable-content-500">
-                     <i class="fa-solid fa-angles-left hidden sidebar-expanded:block"></i>
-                     <i class="fa-solid fa-angles-right sidebar-expanded:hidden"></i>
+                  <button
+                    data-sidebar-target="unpinSidebarButton"
+                    data-action="click->sidebar#unpinSidebar"
+                    class="text-readable-content-400 hover:text-readable-content-500">
+                    <i class="fa-solid fa-angles-left"></i>
                   </button>
-
+                  <button
+                    data-sidebar-target="pinSidebarButton"
+                    data-action="click->sidebar#pinSidebar"
+                    class="text-readable-content-400 hover:text-readable-content-500">
+                    <i class="fa-solid fa-map-pin"></i>
+                  </button>
                </div>
             </div>
             <%= render partial: 'layouts/_sidebar/projects_menu' %>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -9,15 +9,15 @@
             <button data-action="click->sidebar#closeAsMenu" style="right: 15px; top: calc(50% - 16px);" class="absolute z-20 md:hidden text-2xl text-readable-content-400 opacity-80 hover:text-readable-content-700">
                <i class="fa fa-xmark"></i>
             </button>
-            <div class="flex justify-center items-center p-4 hidden sidebar-expanded:block">
-              <%= image_tag 'logo-white.svg', class: "dark-themes-only" , style: 'width: 60%; opacity: 0.8;' %>
-              <%= image_tag 'logo.svg', class: "light-themes-only" , style: 'width: 60%; opacity: 0.8;' %>
-            </div>
+            <a href="<%= root_path %>" class="flex justify-center items-center p-4 hidden sidebar-expanded:block pl-6">
+              <%= image_tag 'logo-white.svg', class: "dark-themes-only" , style: 'width: 150px; opacity: 0.8;' %>
+              <%= image_tag 'logo.svg', class: "light-themes-only" , style: 'width: 150px; opacity: 0.8;' %>
+            </a>
 
-            <div class="flex justify-center items-center p-4 sidebar-expanded:hidden">
-              <%= image_tag 'icon-white.svg', class: "dark-themes-only" , style: 'width: 60%; opacity: 0.8;' %>
-              <%= image_tag 'icon.svg', class: "light-themes-only", style: 'width: 60%; opacity: 0.8;' %>
-            </div>
+            <a href="<%= root_path %>" class="flex justify-center items-center p-4 sidebar-expanded:hidden">
+              <%= image_tag 'icon-white.svg', class: "dark-themes-only" , style: 'width: 40px; opacity: 0.8;' %>
+              <%= image_tag 'icon.svg', class: "light-themes-only", style: 'width: 40px; opacity: 0.8;' %>
+            </a>
          </div>
          <div class="sidebar-expanded:mt-0">
             <div class="px-4 sidebar-expanded:mb-2 sm:h-16 sm:sidebar-expanded:h-auto flex items-center sidebar-expanded:justify-between justify-center uppercase text-readable-content-500 opacity-50 font-semibold">

--- a/app/views/layouts/_sidebar/_projects_menu.html.erb
+++ b/app/views/layouts/_sidebar/_projects_menu.html.erb
@@ -14,15 +14,16 @@
     <% end %>
   </div>
 
-  <div class="max-h-[300px] overflow-y-auto px-8 md:hidden md:sidebar-expanded:block pb-4">
+  <div style='font-size: 0.84rem;' class="max-h-[300px] overflow-y-auto px-8 md:hidden md:sidebar-expanded:block pb-4">
     <%= link_to projects_path,
-        class: "text-xs py-1.5 flex gap-2 items-center font-normal grow text-readable-content-500 hover:font-semibold hover:text-primary-800" do %>
-
+        class: "py-1.5 flex gap-2 items-center font-normal grow text-readable-content-500 hover:font-semibold hover:text-primary-800",
+        style: 'padding: 0.25em 0;' do %>
       <%= t('.list_all_projects') %>
     <% end %>
     <%  Project.active.order(name: :asc).all.each do |project| %>
       <%= link_to project.name, visualization_path(project.default_visualization),
-        class: "block text-xs py-1.5 grow font-normal text-readable-content-500 hover:font-semibold hover:text-primary-800 truncate" %>
+        class: "block grow font-normal text-readable-content-500 hover:font-semibold hover:text-primary-800 truncate",
+        style: 'padding: 0.25em 0;' %>
     <% end %>
 
   </div>


### PR DESCRIPTION
This PR enhances the sidebar menu experience to be more practical for project navigation.

# Changes

- Auto expand the collapsed sidebar on mouse hover
- Minor adjustments to project list font size/spacing
- Adds a 'pin/unpin' button to keep it expanded permanently
- Adds a link (to the root path) on our beautiful Eigenfocus logo 


![sidebar](https://github.com/user-attachments/assets/d4e629c4-b8ff-4357-bc46-52e20ce60235)

# C
