### PR TITLE
Implements "Archive all" on boards

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+eigenfocus_free

--- a/app/controllers/visualizations/groupings_controller.rb
+++ b/app/controllers/visualizations/groupings_controller.rb
@@ -52,6 +52,14 @@ class Visualizations::GroupingsController < Visualizations::BaseController
     end
   end
 
+  def archive_all_issues
+    @grouping = current_visualization.groupings.find(params[:id])
+
+    ActiveRecord::Base.transaction do
+      @grouping.issues.each(&:archive!)
+    end
+  end
+
   private
   def permitted_params
     params.require(:grouping).permit(:title, :hidden)

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -56,7 +56,9 @@
 
         <div class="flex flex-col mt-2 justify-stretch items-stretch">
           <div class="flex flex-col justify-stretch border-b border-background-100 pb-2 mb-2">
-            <h4 class="text-sm font-bold text-readable-content-400 px-4 mb-2">Issues</h4>
+            <h4 class="text-sm font-bold text-readable-content-400 px-4 mb-2">
+              <%= Issue.model_name.human(count: 2) %>
+            </h4>
             <%= link_to t('visualizations.column_menu.create_issue'), "#",
                 class: "cpy-new-issue text-left py-2 px-4 hover:bg-background-100 w-full",
                 data: { action: "click->grouping-column#showInlineCardForm click->dropdown#toggle" } %>
@@ -64,10 +66,20 @@
                 move_all_issues_visualization_grouping_path(grouping.visualization_id, grouping.id),
                 class: "py-2 px-4 hover:bg-background-100 w-full",
                 data: { turbo_frame: 'move_all_issues_modal', action: "click->dropdown#toggle" } %>
+            <%= link_to t('visualizations.column_menu.archive_all_issues'),
+                archive_all_issues_visualization_grouping_path(grouping.visualization_id, grouping.id),
+                class: "py-2 px-4 hover:bg-background-100 w-full",
+                data: {
+                  turbo_method: :post,
+                  turbo_confirm: t("visualizations.column_menu.archive_all_issues_confirmation", title: grouping.title),
+                  action: "click->dropdown#toggle"
+                } %>
           </div>
 
           <div class="flex flex-col justify-stretch">
-            <h4 class="text-sm font-bold text-readable-content-400 px-4 mb-2">Column</h4>
+            <h4 class="text-sm font-bold text-readable-content-400 px-4 mb-2">
+              <%= Grouping.model_name.human(count: 2) %>
+            </h4>
             <%= link_to t('visualizations.column_menu.edit_column'),
                 edit_visualization_grouping_path(grouping.visualization_id, grouping.id),
                 class: "cpy-edit-column py-2 px-4 hover:bg-background-100 w-full",

--- a/app/views/visualizations/groupings/archive_all_issues.turbo_stream.erb
+++ b/app/views/visualizations/groupings/archive_all_issues.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.update "#{@grouping.id}-cards-wrapper", "" %>
+
+<%= new_turbo_stream_alert_message(:success, t("flash.groupings.archive_all_issues.success")) %>

--- a/config/locales/actions.en.yml
+++ b/config/locales/actions.en.yml
@@ -36,6 +36,8 @@ en:
       destroy_confirmation: 'Are you sure you want to delete "%{title}" column? All its issues are going to be moved to "No column"!'
       current_column: 'Current column'
       move_all_issues: Move all issues
+      archive_all_issues: 'Archive all issues'
+      archive_all_issues_confirmation: 'Are you sure you want to archive all issues from "%{title}" column?'
     groupings:
       move_all_issues_modal:
         title: "Move all issues from %{grouping}"

--- a/config/locales/actions.pt-br.yml
+++ b/config/locales/actions.pt-br.yml
@@ -78,6 +78,8 @@ pt-BR:
       destroy_confirmation: 'Tem certeza que quer deletar a coluna "%{title}"? Todas as issues dela serão movidas para "Sem coluna"!'
       current_column: 'Coluna atual'
       move_all_issues: 'Mover todas as issues'
+      archive_all_issues: 'Arquivar todas as issues'
+      archive_all_issues_confirmation: 'Tem certeza que quer arquivar todas as issues da coluna "%{title}"?'
     groupings:
       move_all_issues_modal:
         title: "Mover todas as issues de %{grouping}"

--- a/config/locales/app.en.yml
+++ b/config/locales/app.en.yml
@@ -79,7 +79,9 @@ en:
         success: "Issue column was successfully updated."
     groupings:
       move_all_issues:
-        success: "All issues were successfully moved"
+        success: "All issues were successfully moved."
+      archive_all_issues:
+        success: "All issues were successfully archived."
     actions:
       create:
         notice: "%{resource_name} was successfully created."

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -80,7 +80,9 @@ pt-BR:
         success: "Coluna da issue atualizada com sucesso."
     groupings:
       move_all_issues:
-        success: "Todas as issues foram movidas com sucesso"
+        success: "Todas as issues foram movidas com sucesso."
+      archive_all_issues:
+        success: "Todas as issues foram arquivadas com sucesso."
     actions:
       create:
         notice: "%{resource_name} criado(a) com sucesso."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
         member do
           get :move_all_issues
           post :move_all_issues_to
+          post :archive_all_issues
         end
         collection do
           post :move

--- a/spec/features/project_management/using_views/kanban/archive_all_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/archive_all_issues_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'Groupings - Archive all issues' do
+  let!(:user) { FactoryBot.create(:user) }
+
+  specify 'I can archive all issues from one column' do
+    project = FactoryBot.create(:project)
+    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO")
+
+    3.times do |n|
+      issue = FactoryBot.create(:issue, project: project, title: "Issue #{n}")
+      FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+    end
+
+    visit visualization_path(project.default_visualization)
+
+    within dom_id(grouping) do
+      project.issues.each do |issue|
+        expect(page).to have_content(issue.title)
+      end
+
+      find('.cpy-column-menu-button').click
+      accept_confirm do
+        click_link "Archive all issues"
+      end
+    end
+
+    expect(page).to have_content("All issues were successfully archived")
+
+    expect(project.issues.count).to eq(3)
+
+    within dom_id(grouping) do
+      project.issues.each do |issue|
+        expect(page).not_to have_content(issue.title)
+      end
+    end
+
+    grouping.reload
+    expect(grouping.issues.count).to eq(3)
+    expect(grouping.issues.map(&:archived?)).to match_array([ true, true, true ])
+  end
+end

--- a/spec/features/project_management/using_views/kanban/archive_all_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/archive_all_issues_spec.rb
@@ -37,6 +37,6 @@ describe 'Groupings - Archive all issues' do
 
     grouping.reload
     expect(grouping.issues.count).to eq(3)
-    expect(grouping.issues.map(&:archived?)).to match_array([ true, true, true ])
+    expect(grouping.issues.all(&:archived?)).to be_truthy
   end
 end


### PR DESCRIPTION
## Why?

Some times we want to perform actions in bulk, like move all issues from one column to another. This is great when we need to move all our great work to a different column. 

As projects progress, finished issues tends to accumulate, usually in a collapsed column like "Done" or even "Archived".

Now, we go even further: 

This PR adds the ability to archive all issues from a column, so we can easily hide multiple issues from the board when the're were finished or just needs to be archived for no specific reason.

## Preview

![record](https://github.com/user-attachments/assets/f7a5c0f9-0e1a-446f-802d-c59d15969e76)

## Just a friendly reminder

> Archive is not the same as deleting a column!

Deleting a column moves the issue to a "No column" state, but if you want you can still move them to another column after and they will be displayed on the board.

Archive means the issues shouldn't appear on the board anymore. You can still access them through the "All issues" list. If you want them to reappear on the board, you can unarchive them.

So:
- Archive is more to issues that were finished or won't be done at all
- Delete a column to remove a step on our workflow