### PR TITLE
feat: Issue due date

### DIFF
--- a/app/assets/tailwind/themes/flatpickr.css
+++ b/app/assets/tailwind/themes/flatpickr.css
@@ -25,6 +25,19 @@
     width: calc(var(--daysWidth) + calc(var(--calendarPadding)*2));
 }
 
+.flatpickr-resetable-container {
+    position: relative;
+}
+
+.flatpickr-clear-button {
+  @apply link-cancel;
+  position: absolute;
+  top: 50%;
+  right: 10px;
+  transform: translateY(-50%);
+  z-index: 1;
+}
+
 @screen lg {
     .flatpickr-calendar {
         @apply left-0 right-auto;

--- a/app/assets/tailwind/themes/flatpickr.css
+++ b/app/assets/tailwind/themes/flatpickr.css
@@ -255,11 +255,11 @@ span.flatpickr-weekday {
     display: none;
 }
 
-.flatpickr-year-select  {
+.flatpickr-year-select-wrapper  {
   @apply ml-4;
 }
 
-.flatpickr-year-select select {
+.flatpickr-year-select-wrapper select {
   @apply input-primary;
   width: 85px;
 }

--- a/app/controllers/projects/issues_controller.rb
+++ b/app/controllers/projects/issues_controller.rb
@@ -72,6 +72,6 @@ class Projects::IssuesController < Projects::BaseController
 
   private
   def permitted_params
-    params.require(:issue).permit(:title, :description, files: [], labels_list: [])
+    params.require(:issue).permit(:title, :description, :due_date, files: [], labels_list: [])
   end
 end

--- a/app/controllers/visualizations/issues_controller.rb
+++ b/app/controllers/visualizations/issues_controller.rb
@@ -17,6 +17,6 @@ class Visualizations::IssuesController < Visualizations::BaseController
 
   private
   def permitted_params
-    params.require(:issue).permit(:title, :description, files: [])
+    params.require(:issue).permit(:title, :description, :due_date, files: [])
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,4 +13,5 @@ module ApplicationHelper
   include ApplicationHelper::WebsocketsSecurity
   include ApplicationHelper::IssueEmbedded
   include ApplicationHelper::AppTour
+  include ApplicationHelper::DueDate
 end

--- a/app/helpers/application_helper/due_date.rb
+++ b/app/helpers/application_helper/due_date.rb
@@ -1,0 +1,28 @@
+module ApplicationHelper
+  module DueDate
+    def due_date_for(issue)
+      return unless issue.due_date?
+
+      options = {
+        class: due_date_class_for(issue)
+      }
+
+      content_tag(:span, options) do
+        I18n.l(issue.due_date, format: :short)
+      end
+    end
+
+    private
+
+    def due_date_class_for(issue)
+      return unless issue.due_date?
+
+      case issue.due_date
+      when 1.day.from_now..3.days.from_now
+        "text-alert-500"
+      when Date.new..1.day.from_now
+        "text-danger-500"
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper/modal.rb
+++ b/app/helpers/application_helper/modal.rb
@@ -30,7 +30,7 @@ module Modal
       content_tag(:div, container_options) do
         content_tag(:div, inner_container_options) do
           output = <<-HTML
-            <a class="absolute text-xl top-4 right-4 cursor-pointer text-md text-readable-content-500" data-action="click->modal#close">
+            <a class="cpy-close-modal absolute text-xl top-4 right-4 cursor-pointer text-md text-readable-content-500" data-action="click->modal#close">
               <i class="fa fa-close"></i>
             </a>
             <div class="m-1 bg-body-contrast rounded shadow-lg">

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -82,7 +82,7 @@ const yearDropdownPlugin = function (pluginConfig) {
   return function (fp) {
       fp.yearSelectContainer = fp._createElement(
           "div",
-          "flatpickr-year-select " + config.theme + "Theme",
+          "flatpickr-year-select-wrapper " + config.theme + "Theme",
           config.text
       );
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -112,9 +112,30 @@ const yearDropdownPlugin = function (pluginConfig) {
   };
 }
 
+const clearButtonPlugin = function (pluginConfig) {
+
+  return function (fp) {
+    const clearButton = document.createElement('button')
+    clearButton.innerHTML = '<i class="fa-solid fa-arrow-rotate-left"></i>'
+    clearButton.className = 'flatpickr-clear-button cpy-flatpickr-clear-button'
+
+    clearButton.addEventListener('click', (e) => {
+      e.stopPropagation()
+      fp.clear()
+      fp.close()
+    })
+
+    return {
+      onReady: function onReady() {
+        pluginConfig.input.insertAdjacentElement('afterend', clearButton)
+      }
+    }
+  }
+}
 // create a new Stimulus controller by extending stimulus-flatpickr wrapper controller
 class CustomFlatpickr extends Flatpickr {
   initialize() {
+    super.initialize()
     // sets your language (you can also set some global setting for all time pickers)
 
     this.config = {
@@ -124,9 +145,18 @@ class CustomFlatpickr extends Flatpickr {
           date: this.element.value,
           yearStart: 10,
           yearEnd: 10
+        }),
+        clearButtonPlugin({
+          input: this.element
         })
-      ]
+      ],
     }
+  }
+
+  clear() {
+    this.instance.clear()
+    this.element.value = ''
+    this.dispatch('clear')
   }
 }
 // Manually register Flatpickr as a stimulus controller

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -62,7 +62,7 @@ class Issue < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    [ "title", "created_at", "updated_at" ]
+    [ "title", "due_date", "created_at", "updated_at" ]
   end
 
   def self.ransackable_associations(auth_object = nil)

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -34,7 +34,7 @@
       <div class="flex flex-col md:flex-row gap-8">
 
         <%= render partial: 'issues/issue_detail/main_form', locals: { issue:, form_path: local_assigns[:form_path] } %>
-        <%= render partial: 'issues/issue_detail/right_sidebar', locals: { issue: } %>
+        <%= render partial: 'issues/issue_detail/right_sidebar', locals: { issue:, form_path: local_assigns[:form_path] } %>
 
       </div>
     </div>

--- a/app/views/issues/issue_detail/_right_sidebar.html.erb
+++ b/app/views/issues/issue_detail/_right_sidebar.html.erb
@@ -5,6 +5,16 @@
       <%= render partial: 'issues/issue_detail/grouping_picker', locals: { issue: issue } %>
     <% end %>
 
+    <%= form_with(model: issue, url: form_path, html: {
+      class: 'mb-4 flex flex-col items-stretch gap-2',
+      data: { controller: "form", turbo: true }
+      }) do |f| %>
+        <%= f.label :due_date, Issue.human_attribute_name(:due_date), class: "label-primary" %>
+        <%= f.text_field :due_date, class: 'input-primary w-full',
+          data: { "flatpickr-date-format": "Y-m-d", controller: "flatpickr", action: "input->form#submit" }
+          %>
+    <% end %>
+
     <% unless issue.archived? %>
       <%= link_to time_entries_path(new_entry: { project_id: issue.project_id, issue_id: issue.id }), class: "mt-8 btn-outline-primary text-nowrap flex gap-2 items-center py-2 tour--issue-detail-time-tracking", data: { turbo_frame: "_top" } do %>
         <%= icon_for(:time_entries) %>

--- a/app/views/issues/issue_detail/_right_sidebar.html.erb
+++ b/app/views/issues/issue_detail/_right_sidebar.html.erb
@@ -11,7 +11,7 @@
       }) do |f| %>
         <%= f.label :due_date, Issue.human_attribute_name(:due_date), class: "label-primary" %>
         <%= f.text_field :due_date, class: 'input-primary w-full',
-          data: { "flatpickr-date-format": "Y-m-d", controller: "flatpickr", action: "input->form#submit" }
+          data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr", action: "input->form#submit" }
           %>
     <% end %>
 

--- a/app/views/issues/issue_detail/_right_sidebar.html.erb
+++ b/app/views/issues/issue_detail/_right_sidebar.html.erb
@@ -10,9 +10,11 @@
       data: { controller: "form", turbo: true }
       }) do |f| %>
         <%= f.label :due_date, Issue.human_attribute_name(:due_date), class: "label-primary" %>
-        <%= f.text_field :due_date, class: 'input-primary w-full',
-          data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr", action: "input->form#submit" }
-          %>
+        <div class="flatpickr-resetable-container">
+          <%= f.text_field :due_date, class: 'input-primary w-full',
+            data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr", action: "input->form#submit" }
+            %>
+        </div>
     <% end %>
 
     <% unless issue.archived? %>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,6 +1,6 @@
-<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "cpy-filter-form", data: { controller: 'form' } do |f| %>
-  <div class="flex flex-col md:flex-row justify-between items-stretch gap-4">
-    <div class="flex flex-col md:flex-row justify-start items-stretch gap-4">
+<%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "w-full cpy-filter-form", data: { controller: 'form' } do |f| %>
+  <div class="flex flex-col lg:flex-row justify-between items-stretch gap-4">
+    <div class="flex flex-col lg:flex-row justify-start items-stretch gap-4">
       <div class="flex gap-2 grow items-center cpy-by-status">
         <%= f.select :by_archiving_status, ['all', 'active', 'archived'].map { |status| [t(".by_archiving_status.#{status}"), status] },
           { include_hidden: false },
@@ -11,12 +11,12 @@
         %>
       </div>
 
-      <div class="flex gap-2 md:w-60 items-center">
+      <div class="flex gap-2 lg:w-60 items-center">
         <%= f.label :title_cont, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
         <%= f.search_field :title_cont, class: 'input-contrast input-sm' %>
       </div>
 
-      <div class="flex gap-2 md:grow md:w-72 items-center cpy-by-labels-titles">
+      <div class="flex gap-2 lg:grow lg:w-72 items-center cpy-by-labels-titles">
         <%= f.label :by_label_titles, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
         <%= f.select :by_label_titles, current_project.issue_labels.pluck(:title),
                   { include_hidden: false },
@@ -29,6 +29,21 @@
                 %>
       </div>
 
+      <div class="flex gap-2 lg:w-56 items-center">
+        <%= f.label :due_date_gteq, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
+        <%= f.search_field :due_date_gteq,
+          class: 'input-contrast input-sm',
+          data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr" }
+        %>
+      </div>
+
+      <div class="flex gap-2 lg:w-56 items-center">
+        <%= f.label :due_date_lteq, class: "text-readable-content-500 text-nowrap font-medium text-xs" %>
+        <%= f.search_field :due_date_lteq,
+          class: 'input-contrast input-sm',
+          data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr" }
+        %>
+      </div>
 
       <div class="flex gap-4 items-stretch">
         <%= f.button class: "btn-primary flex items-center grow" do %>

--- a/app/views/projects/issues/_filter.html.erb
+++ b/app/views/projects/issues/_filter.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for q, url: project_issues_path(project_id: current_project.id), class: "w-full cpy-filter-form", data: { controller: 'form' } do |f| %>
   <div class="flex flex-col lg:flex-row justify-between items-stretch gap-4">
-    <div class="flex flex-col lg:flex-row justify-start items-stretch gap-4">
+    <div class="flex flex-col lg:flex-row justify-start items-stretch gap-4 flex-wrap">
       <div class="flex gap-2 grow items-center cpy-by-status">
         <%= f.select :by_archiving_status, ['all', 'active', 'archived'].map { |status| [t(".by_archiving_status.#{status}"), status] },
           { include_hidden: false },

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -21,9 +21,7 @@
     <% end %>
   </td>
   <td>
-    <% if issue.due_date? %>
-      <%= l issue.due_date, format: :short %>
-    <% end %>
+    <%= due_date_for(issue) %>
   </td>
   <td><%= l issue.created_at, format: :short %></td>
   <td><%= l issue.updated_at, format: :short %></td>

--- a/app/views/projects/issues/_issue.html.erb
+++ b/app/views/projects/issues/_issue.html.erb
@@ -20,6 +20,11 @@
       <%= t(".no_grouping") %>
     <% end %>
   </td>
+  <td>
+    <% if issue.due_date? %>
+      <%= l issue.due_date, format: :short %>
+    <% end %>
+  </td>
   <td><%= l issue.created_at, format: :short %></td>
   <td><%= l issue.updated_at, format: :short %></td>
   <td class="tour--issue-actions">

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -10,7 +10,7 @@
 } %>
 
 <%= turbo_frame_tag 'issues', class: "tour--issues-list", autoscroll: true, 'autoblock-scroll': 'start', data: { turbo_action: "advance" } do %>
-  <div class="mt-8 mb-8 flex justify-between gap-4 items-center flex-col md:flex-row">
+  <div class="mt-8 mb-8 flex justify-between gap-4 items-center flex-col lg:flex-row">
     <%= render partial: 'filter', locals: { q: @q } %>
 
     <%= link_to "#{t('actions.create')} #{Issue.model_name.human.downcase}",
@@ -45,6 +45,7 @@
             <th><%= sort_link(@q, :title, Issue.human_attribute_name(:title)) %></th>
             <th><%= Issue.human_attribute_name(:labels) %></th>
             <th><%= sort_link(@q, :groupings_title, Issue.human_attribute_name(:grouping)) %></th>
+            <th><%= sort_link(@q, :due_date, Issue.human_attribute_name(:due_date)) %></th>
             <th><%= sort_link(@q, :created_at, Issue.human_attribute_name(:created_at)) %></th>
             <th><%= sort_link(@q, :updated_at, Issue.human_attribute_name(:updated_at)) %></th>
             <th><%= t(:actions, scope: :menu) %></th>

--- a/app/views/projects/issues/index.html.erb
+++ b/app/views/projects/issues/index.html.erb
@@ -10,9 +10,9 @@
 } %>
 
 <%= turbo_frame_tag 'issues', class: "tour--issues-list", autoscroll: true, 'autoblock-scroll': 'start', data: { turbo_action: "advance" } do %>
-  <div class="mt-8 mb-8 flex justify-between gap-4 items-center flex-col lg:flex-row">
-    <%= render partial: 'filter', locals: { q: @q } %>
+  <%= render partial: 'filter', locals: { q: @q } %>
 
+  <div class="mt-8 mb-8 flex justify-end gap-4 items-center flex-col lg:flex-row">
     <%= link_to "#{t('actions.create')} #{Issue.model_name.human.downcase}",
         new_project_issue_path(current_project),
         class: "btn-primary btn-md tour--create-issue",

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -24,5 +24,9 @@
     <%= labels_list_for(issue) %>
 
     <%= render partial: 'visualizations/groupings/_card/icons', locals: { issue: } %>
+
+    <% if issue.due_date? %>
+      <span><%= l(issue.due_date, format: :short) %></span>
+    <% end %>
   <% end %>
 </li>

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -25,8 +25,6 @@
 
     <%= render partial: 'visualizations/groupings/_card/icons', locals: { issue: } %>
 
-    <% if issue.due_date? %>
-      <span><%= l(issue.due_date, format: :short) %></span>
-    <% end %>
+    <%= due_date_for(issue) %>
   <% end %>
 </li>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -52,6 +52,7 @@ en:
         label_ids: 'Labels'
         created_at: 'Created at'
         updated_at: 'Updated at'
+        due_date: 'Due date'
         grouping: 'Column'
 
       issue_label:

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -52,6 +52,7 @@ pt-BR:
         label_ids: 'Labels'
         created_at: 'Criado em'
         updated_at: 'Atualizado em'
+        due_date: 'Data de encerramento'
         grouping: 'Coluna'
 
       issue_label:

--- a/config/locales/app.pt-BR.yml
+++ b/config/locales/app.pt-BR.yml
@@ -137,7 +137,7 @@ pt-BR:
       day_single_digit: "%e"
       weekday_name: "%^A"
       short_weekday_name: "%a"
-      flatpickr: "%Y-%m-%d"
+      flatpickr: "%d-%m-%Y"
       default: "%d/%b/%Y"
       long: "%d de %B de %Y"
       short: "%d de %B"

--- a/config/locales/ransack.en.yml
+++ b/config/locales/ransack.en.yml
@@ -13,3 +13,5 @@ en:
       issue:
         title_cont: With title
         by_label_titles: With labels
+        due_date_gteq: Due after
+        due_date_lteq: Due before

--- a/config/locales/ransack.pt-BR.yml
+++ b/config/locales/ransack.pt-BR.yml
@@ -13,3 +13,5 @@ pt-BR:
       issue:
         title_cont: Com título
         by_label_titles: Com labels
+        due_date_gteq: Encerra depois de
+        due_date_lteq: Encerra antes de

--- a/db/migrate/20250430151615_add_due_date_to_issues.rb
+++ b/db/migrate/20250430151615_add_due_date_to_issues.rb
@@ -1,0 +1,5 @@
+class AddDueDateToIssues < ActiveRecord::Migration[8.0]
+  def change
+    add_column :issues, :due_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_29_182244) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_30_151615) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -97,6 +97,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_29_182244) do
     t.datetime "updated_at", null: false
     t.integer "project_id"
     t.datetime "archived_at"
+    t.date "due_date"
     t.index ["archived_at"], name: "index_issues_on_archived_at"
     t.index ["project_id"], name: "index_issues_on_project_id"
   end

--- a/spec/features/project_management/all_issues/listing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/listing_issues_spec.rb
@@ -55,4 +55,48 @@ describe 'As a project manager, I want to list my issues' do
     expect(page).to have_content("Debug code")
     expect(page).to have_content("Archived issue")
   end
+
+  specify "I can filter issues by due date" do
+    project = FactoryBot.create(:project)
+
+    FactoryBot.create(:issue, project: project, due_date: Date.new(2025, 1, 1), title: "Due to January")
+    FactoryBot.create(:issue, project: project, due_date: Date.new(2025, 2, 1), title: "Due to February")
+    FactoryBot.create(:issue, project: project, due_date: Date.new(2025, 3, 1), title: "Due to March")
+
+    visit project_issues_path(project)
+
+    expect(page).to have_content("Due to January")
+    expect(page).to have_content("Due to February")
+    expect(page).to have_content("Due to March")
+
+    within ".cpy-filter-form" do
+      fill_in "q[due_date_gteq]", with: "2025-01-15"
+
+      click_button "Search"
+    end
+
+    expect(page).not_to have_content("Due to January")
+    expect(page).to have_content("Due to February")
+    expect(page).to have_content("Due to March")
+
+    within ".cpy-filter-form" do
+      fill_in "q[due_date_lteq]", with: "2025-02-15"
+
+      click_button "Search"
+    end
+
+    expect(page).not_to have_content("Due to January")
+    expect(page).to have_content("Due to February")
+    expect(page).not_to have_content("Due to March")
+
+    within ".cpy-filter-form" do
+      fill_in "q[due_date_gteq]", with: ""
+
+      click_button "Search"
+    end
+
+    expect(page).to have_content("Due to January")
+    expect(page).to have_content("Due to February")
+    expect(page).not_to have_content("Due to March")
+  end
 end

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -173,7 +173,7 @@ describe 'As a user, I want to manage my project using a kanban view' do
 
       expect(page).to have_content("Edit Issue")
 
-      select_flatpickr_day '#issue_due_date', "23"
+      select_from_flatpickr '#issue_due_date', "23-04-2025"
 
       close_modal
 

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -170,15 +170,21 @@ describe 'As a user, I want to manage my project using a kanban view' do
       click_link "Issue testing due date"
     end
 
+    expect(page).to have_content("Edit Issue")
+
     within '#issue_detail' do
+      expect(page).to have_selector("#issue_due_date.flatpickr-input")
+
       fill_in :issue_due_date, with: "2025-06-23"
+
+      expect(page).to have_selector("#issue_due_date.flatpickr-input.active")
     end
 
     expect(page).to have_content("Issue was successfully updated.")
     # Modal is still open
     expect(page).to have_selector('#issue_detail', visible: true)
 
-    issue = Issue.last
+    issue.reload
     expect(issue.due_date).to eq(Date.new(2025, 6, 23))
   end
 

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -158,6 +158,30 @@ describe 'As a user, I want to manage my project using a kanban view' do
     expect(issue.title).to eq("Updated title")
   end
 
+  specify "I can update the due date" do
+    project = FactoryBot.create(:project)
+    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
+    issue = FactoryBot.create(:issue, title: "Issue testing due date", project: project)
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+
+    visit visualization_path(project.default_visualization)
+
+    within dom_id(grouping) do
+      click_link "Issue testing due date"
+    end
+
+    within '#issue_detail' do
+      fill_in :issue_due_date, with: "2025-06-23"
+    end
+
+    expect(page).to have_content("Issue was successfully updated.")
+    # Modal is still open
+    expect(page).to have_selector('#issue_detail', visible: true)
+
+    issue = Issue.last
+    expect(issue.due_date).to eq(Date.new(2025, 6, 23))
+  end
+
   specify 'I can move issues within the same grouping' do
     project = FactoryBot.create(:project)
     grouping = FactoryBot.create(:grouping, visualization: project.default_visualization, title: "TODO")

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -159,33 +159,33 @@ describe 'As a user, I want to manage my project using a kanban view' do
   end
 
   specify "I can update the due date" do
-    project = FactoryBot.create(:project)
-    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
-    issue = FactoryBot.create(:issue, title: "Issue testing due date", project: project)
-    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+    Timecop.freeze '2025-06-20'.to_date do
+      project = FactoryBot.create(:project)
+      grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
+      issue = FactoryBot.create(:issue, title: "Issue testing due date", project: project)
+      FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
 
-    visit visualization_path(project.default_visualization)
+      visit visualization_path(project.default_visualization)
 
-    within dom_id(grouping) do
-      click_link "Issue testing due date"
+      within dom_id(grouping) do
+        click_link "Issue testing due date"
+      end
+
+      expect(page).to have_content("Edit Issue")
+
+      select_flatpickr_day '#issue_due_date', "23"
+
+      close_modal
+
+      expect(page).to have_content("Issue was successfully updated.")
+
+      within dom_id(issue) do
+        expect(page).to have_content("23 April")
+      end
+
+      issue.reload
+      expect(issue.due_date).to eq(Date.new(2025, 4, 23))
     end
-
-    expect(page).to have_content("Edit Issue")
-
-    within '#issue_detail' do
-      expect(page).to have_selector("#issue_due_date.flatpickr-input")
-
-      fill_in :issue_due_date, with: "2025-06-23"
-
-      expect(page).to have_selector("#issue_due_date.flatpickr-input.active")
-    end
-
-    expect(page).to have_content("Issue was successfully updated.")
-    # Modal is still open
-    expect(page).to have_selector('#issue_detail', visible: true)
-
-    issue.reload
-    expect(issue.due_date).to eq(Date.new(2025, 6, 23))
   end
 
   specify 'I can move issues within the same grouping' do

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -159,7 +159,7 @@ describe 'As a user, I want to manage my project using a kanban view' do
   end
 
   specify "I can update the due date" do
-    Timecop.freeze '2025-06-20'.to_date do
+    Timecop.freeze '2025-04-20'.to_date do
       project = FactoryBot.create(:project)
       grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
       issue = FactoryBot.create(:issue, title: "Issue testing due date", project: project)
@@ -186,6 +186,26 @@ describe 'As a user, I want to manage my project using a kanban view' do
       issue.reload
       expect(issue.due_date).to eq(Date.new(2025, 4, 23))
     end
+  end
+
+  specify "I can clear the due date" do
+    project = FactoryBot.create(:project)
+    grouping = FactoryBot.create(:grouping, visualization: project.default_visualization)
+    issue = FactoryBot.create(:issue, title: "Issue testing due date", project: project, due_date: Date.new(2025, 4, 23))
+    FactoryBot.create(:grouping_issue_allocation, issue: issue, grouping: grouping)
+
+    visit visualization_path(project.default_visualization)
+
+    within dom_id(grouping) do
+      click_link "Issue testing due date"
+    end
+
+    find(".cpy-flatpickr-clear-button").click
+
+    expect(page).to have_content("Issue was successfully updated.")
+
+    issue.reload
+    expect(issue.due_date).to be_nil
   end
 
   specify 'I can move issues within the same grouping' do

--- a/spec/support/helpers/flatpickr.rb
+++ b/spec/support/helpers/flatpickr.rb
@@ -1,10 +1,14 @@
 module FlatpicrHelpers
-  def select_flatpickr_day(selector, day)
+  def select_from_flatpickr(selector, date)
     page.execute_script "$('#{selector}').trigger('focus')"
 
-    within '.flatpickr-days' do
-      find(".flatpickr-day", text: day).click
-    end
+    date_obj = date.is_a?(Date) ? date : Date.parse(date.to_s)
+
+    find('.flatpickr-year-select-wrapper select').select(date_obj.year.to_s)
+
+    find('select.flatpickr-monthDropdown-months').select(date_obj.strftime('%B'))
+
+    find(".flatpickr-day", text: date_obj.day.to_s).click
   end
 end
 

--- a/spec/support/helpers/flatpickr.rb
+++ b/spec/support/helpers/flatpickr.rb
@@ -1,0 +1,13 @@
+module FlatpicrHelpers
+  def select_flatpickr_day(selector, day)
+    page.execute_script "$('#{selector}').trigger('focus')"
+
+    within '.flatpickr-days' do
+      find(".flatpickr-day", text: day).click
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include FlatpicrHelpers, type: :feature
+end

--- a/spec/support/helpers/modal.rb
+++ b/spec/support/helpers/modal.rb
@@ -1,0 +1,9 @@
+module ModalHelpers
+  def close_modal
+    find(".cpy-close-modal").click
+  end
+end
+
+RSpec.configure do |config|
+  config.include ModalHelpers, type: :feature
+end


### PR DESCRIPTION
## Why?

Time is always running, it never stops. Wouldn't it be nice if we could know when that task should be finished?

Well, now we can!

This PR adds the `due date` field to the issues, so we can keep on track of how close things are to their delivery or even when that big event is going to happen.

## Preview

The due date color changes based on how close the due date is. This way we can easily spot issues that may need our attention

- Red for issues overdue or within 1 day to the due date
- Yellow for issues within 1 to 3 days to the due date
- Default text color otherwise

![record](https://github.com/user-attachments/assets/63060abf-443d-492f-a65b-6e8a96118ce9)

![image](https://github.com/user-attachments/assets/17f0f7ee-f42a-4980-81d7-fea7e3996d70)
