### PR TITLE
test: Fixes flaky specs caused by custom data-confirm modals

### DIFF
--- a/spec/support/helpers/turbo_confirm.rb
+++ b/spec/support/helpers/turbo_confirm.rb
@@ -4,10 +4,9 @@ class Capybara::Session
   def accept_alert
     yield
 
-    # We use document here to avoid problem with method been called inside
-    # a `within` scope
     if document.has_selector?("#confirm-modal-background")
-      document.click_button("confirm-accept")
+      # Using pure JS to escape the scope `within` blocks
+      document.evaluate_script('document.querySelector(".confirm-modal #confirm-accept").click()')
     else
       throw ConfirmModalNotFound.new("Unable to find confirm modal")
     end


### PR DESCRIPTION
After introducing custom alert modals for `data-confirm`, some specs started failing inconsistently.

The issue was that `accept_alert` was being called inside `within` blocks, which prevented Capybara from properly detecting the `confirm-accept` button.

Fun fact: the button was being found sometimes, but not always... making debugging extra fun. 👀

