### PR TITLE
Adjustments to production setup

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -19,27 +19,9 @@ setup_upload_folder()
   mkdir -p ./app-data/upload-storage
 }
 
-shutdown_handler() {
-  echo "Received shutdown signal, shutting down..."
-  # Kill the application process
-  kill "$child"
-  # Wait for the application to exit
-  wait "$child"
-  echo "Application stopped."
-  exit 0
-}
-
-trap "shutdown_handler" SIGTERM SIGINT
-
 load_or_create_secret_env
 setup_upload_folder
 
 cp config/database.example.yml config/database.yml
 
-
-# Start the command in the background
-"${@}" &
-child=$!
-
-# Wait for the process to finish
-wait "$child"
+exec "${@}"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
-  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "warn")
 
   # Prevent health checks from clogging up the logs.
   config.silence_healthcheck_path = "/up"


### PR DESCRIPTION
- Changes rails log level to warn
- Updates docker entrypoint no need to manually trap sigterms as `bin/bin` is starting the rails server using `exec`. 