### PR TITLE
chore: adds i18n for dates on frontend app

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,4 +1,5 @@
 RAILS_ENV=development
+NODE_ENV=development
 
 # Server
 RAILS_HOST_PORT=3000

--- a/frontend/components/HelloWorld.js
+++ b/frontend/components/HelloWorld.js
@@ -1,10 +1,13 @@
 import React from "react"
 import PropTypes from "prop-types"
+import dateFormat from "shared/date-format";
 
 const HelloWorld = (props) => {
   return (
     <React.Fragment>
       Greeting: {props.greeting}
+      <br />
+      Date: {dateFormat(new Date(), "d MMM")}
     </React.Fragment>
   )
 }

--- a/frontend/shared/date-format.js
+++ b/frontend/shared/date-format.js
@@ -1,0 +1,19 @@
+import { format } from "date-fns";
+import { enUS, ptBR } from "date-fns/locale";
+
+const locales = { enUS, ptBR };
+
+function getLocale() {
+  const locale = document.documentElement.lang;
+  if (locale == 'pt-BR') {
+    return 'ptBR';
+  } else {
+    return 'enUS';
+  }
+}
+// https://date-fns.org/v4.1.0/docs/I18n
+export default function dateFormat(date, formatStr = "PP") {
+  return format(date, formatStr, {
+    locale: locales[getLocale()],
+  });
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "compression-webpack-plugin": "^9.2.0",
     "css-loader": "^7.1.2",
     "css-minimizer-webpack-plugin": "^7.0.0",
+    "date-fns": "^4.1.0",
     "i18n-js": "^4.5.1",
     "mini-css-extract-plugin": "^2.9.2",
     "prop-types": "^15.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3628,6 +3628,11 @@ csso@^5.0.5:
   dependencies:
     css-tree "~2.2.0"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Our next features requires a lot of date formatting in the frontend React app. 

This PR adds `date-fns` lib that automatically formats dates based on the user's preferred language.

# Bonus 

Build on shakapacker was displaying this message:


> ⚠️ WARNING
> Setting 'useContentHash' to 'false' in the production environment (specified by NODE_ENV environment variable) is not allowed!
> Content hashes get added to the filenames regardless of setting useContentHash in 'shakapacker.yml' to false.

So I've changed `example.env` to have NODE_ENV set to development

