### PR TITLE
Adds a default date format to flatpickr

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -142,6 +142,10 @@ const clearButtonPlugin = function (pluginConfig) {
 // create a new Stimulus controller by extending stimulus-flatpickr wrapper controller
 class CustomFlatpickr extends Flatpickr {
   initialize() {
+    if (!this.element.dataset.flatpickrDateFormat) {
+      this.element.dataset.flatpickrDateFormat = "Y-m-d";
+    }
+
     super.initialize()
 
     const showClearButton = this.element.dataset.showClearButton

--- a/app/views/issues/issue_detail/_right_sidebar.html.erb
+++ b/app/views/issues/issue_detail/_right_sidebar.html.erb
@@ -12,7 +12,7 @@
         <%= f.label :due_date, Issue.human_attribute_name(:due_date), class: "label-primary" %>
         <div class="flatpickr-resetable-container">
           <%= f.text_field :due_date, class: 'input-primary w-full',
-            data: { "flatpickr-date-format": t("date.formats.flatpickr"), controller: "flatpickr", action: "input->form#submit", show_clear_button: true }
+            data: { controller: "flatpickr", action: "input->form#submit", show_clear_button: true }
             %>
         </div>
     <% end %>

--- a/app/views/reports/_total_time/_filters.html.erb
+++ b/app/views/reports/_total_time/_filters.html.erb
@@ -33,7 +33,7 @@
           <%= f.label :reference_date_gteq, t(".entry_start_at"), class: "text-readable-content-500 text-sm " %>
 
           <%= f.text_field :reference_date_gteq, class: 'input-primary w-full',
-            data: { "flatpickr-date-format": "Y-m-d", controller: "flatpickr" }
+            data: { controller: "flatpickr" }
           %>
         </div>
 
@@ -43,7 +43,7 @@
 
           <%= f.text_field :reference_date_lteq,
             class: 'input-primary w-full',
-            data: { "flatpickr-date-format": "Y-m-d", controller: "flatpickr" }
+            data: { controller: "flatpickr" }
           %>
         </div>
       </div>

--- a/app/views/time_entries/index.html.erb
+++ b/app/views/time_entries/index.html.erb
@@ -42,7 +42,6 @@
       placeholder="Reference Date"
       data-controller="flatpickr"
       data-action="change->form#submit"
-      data-flatpickr_date_format="Y-m-d"
       data-flatpickr-min-date="2019-01-01"
       data-flatpickr-max-date="2030-01-01"
       value="<%= l @reference_date, format: :flatpickr %>" type="text" readonly="readonly">


### PR DESCRIPTION
In the future we may add a `data-flatpickr-date-format="<%= t("date.formats.flatpickr") %>"` to the html tag and localize flatpickr dates but, for now, it's not worth the effort. 