### PR TITLE
Dynamically sets label text colors via css

### DIFF
--- a/app/assets/tailwind/themes/_components/issue-label.css
+++ b/app/assets/tailwind/themes/_components/issue-label.css
@@ -1,12 +1,21 @@
+:root {
+  --label-bg: rgb(219 234 254);
+}
+
 .issue-label {
-  @apply inline-flex bg-background-100 items-center border-readable-content-400/40 text-readable-content-500 border border;
+  @apply inline-flex items-center;
+  background-color: var(--label-bg);
   font-size: 12px;
   border-radius: 4px;
   padding: 1px 4px;
 }
 
+.issue-label > .label-text {
+  color: #fff;
+  mix-blend-mode: difference;
+}
+
 .issue-label.big {
   font-size: 14px;
   padding: 3px 6px;
-
 }

--- a/app/helpers/application_helper/labels.rb
+++ b/app/helpers/application_helper/labels.rb
@@ -2,7 +2,7 @@ module ApplicationHelper
   module Labels
     def badge_for_issue_label(label, label_tag_options = {})
       custom_styles = if label.hex_color.present?
-        "background-color: #{label.hex_color}"
+        "--label-bg: #{label.hex_color}"
       else
         ""
       end
@@ -16,7 +16,7 @@ module ApplicationHelper
       }.merge(label_tag_options)
 
       content_tag(:span, options) do
-        label.title
+        concat content_tag(:span, label.title, class: "label-text")
       end
     end
 


### PR DESCRIPTION
Befor, depending on the luminosity chosen for the label, the text was not readable. 

Now, the text color is set relative to the background color using css blend modes. Ideally we should use CSS `color-contrast` but it's an experimental feature yet. 

OR, we probably should add a text color option to the label