### PR TITLE
fix: data-confirm modal blurs clicked button on show

### DIFF
--- a/app/javascript/initializers/turbo_confirm/index.js
+++ b/app/javascript/initializers/turbo_confirm/index.js
@@ -8,6 +8,10 @@ TC.start({
   showConfirmCallback: element => {
     element.modal && element.modal.open()
     element.showModal && element.showModal()
+     // without the blur, if the user press ENTER
+     // it will open multiple modals because the element that
+     // was focused is the one that opened the confirm dialog
+    document.activeElement.blur()
   },
   hideConfirmCallback: element => {
     element.close && element.close()


### PR DESCRIPTION
This PR fixes a behaviour where if I click on an element with `data-confirm` and press "Enter/Return" it would open 'multiple modals' with many backdrop backgrounds