### PR TITLE
UI adjustments to issue comments

### DIFF
--- a/app/javascript/controllers/issue/comments_controller.js
+++ b/app/javascript/controllers/issue/comments_controller.js
@@ -1,7 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["formSection", "showFormButton"]
+  static targets = [
+    "formSection",
+    "showFormButton",
+    "comment"
+  ]
 
   showForm() {
     this.formSectionTarget.classList.remove('hidden')
@@ -11,5 +15,14 @@ export default class extends Controller {
   hideForm() {
     this.formSectionTarget.classList.add('hidden')
     this.showFormButtonTarget.classList.remove('hidden')
+  }
+
+  commentTargetConnected(element) {
+    const authorId = element.dataset.authorId
+    const currentUserId = this.element.dataset.currentUserId
+
+    if (authorId == currentUserId) {
+      element.querySelector('.js-comment-actions').classList.remove('hidden')
+    }
   }
 }

--- a/app/views/issues/comments/_comment.html.erb
+++ b/app/views/issues/comments/_comment.html.erb
@@ -4,7 +4,7 @@
       <%= t(".created_at", date: l(comment.created_at, format: :long)) %>
     </div>
     <%= react_component("MarkdownEditor", defaultValue: comment.content, readOnly: true) %>
-    <div class="flex justify-between text-xs">
+    <div class="flex justify-between text-xs px-2">
       <div class="gap-1 flex justify-end">
         <%= link_to edit_issue_comment_path(comment.issue, comment),
           class: "link-primary" do %>

--- a/app/views/issues/comments/_comment.html.erb
+++ b/app/views/issues/comments/_comment.html.erb
@@ -1,10 +1,10 @@
 <%= turbo_frame_tag dom_id(comment) do %>
-  <div class="space-y-2">
+  <div class="space-y-2" data-author-id="<%= comment.author_id %>" data-issue--comments-target="comment">
     <div class="text-xs text-readable-content-500 italic pl-2">
       <%= t(".created_at", date: l(comment.created_at, format: :long)) %>
     </div>
     <%= react_component("MarkdownEditor", defaultValue: comment.content, readOnly: true) %>
-    <div class="flex justify-between text-xs px-2">
+    <div class="flex justify-between text-xs px-2 hidden js-comment-actions">
       <div class="gap-1 flex justify-end">
         <%= link_to edit_issue_comment_path(comment.issue, comment),
           class: "link-primary" do %>

--- a/app/views/issues/comments/_comments.html.erb
+++ b/app/views/issues/comments/_comments.html.erb
@@ -19,7 +19,7 @@
     <%= render partial: "issues/comments/form", locals: { comment: Issue::Comment.new(issue: issue) } %>
   </div>
 
-  <div id="issue-comments-list" class="cpy-comments-list mt-4 flex flex-col gap-6">
+  <div id="issue-comments-list" class="cpy-comments-list mt-6 flex flex-col gap-6">
     <%= render partial: "issues/comments/comment", collection: issue.comments.sort_by(&:created_at).reverse %>
   </div>
 </div>

--- a/app/views/issues/comments/_comments.html.erb
+++ b/app/views/issues/comments/_comments.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_stream_from "issue_#{issue.id}/comments" %>
 
-<div class="cpy-comments-container" data-controller="issue--comments">
+<div class="cpy-comments-container" data-controller="issue--comments" data-current-user-id="<%= current_user.id %>">
   <div class="mt-2 mb-2 flex justify-between">
     <h3 class="text-lg font-medium text-readable-content-500">
       <span class="mr-1 text-readable-content-500/80"><%= icon_for(:comments) %></span>

--- a/app/views/issues/comments/update.turbo_stream.erb
+++ b/app/views/issues/comments/update.turbo_stream.erb
@@ -1,6 +1,10 @@
 <% if @comment.valid? %>
   <%= turbo_stream.replace(@comment, partial: "issues/comments/comment", locals: { comment: @comment }) %>
-  <%= new_turbo_stream_alert_message(:success, t_flash_message(@comment)) %>
+
+  <% unless params[:commit] == "cancel" %>
+    <%= new_turbo_stream_alert_message(:success, t_flash_message(@comment)) %>
+  <% end %>
+
 <% else %>
   <%= new_turbo_stream_alert_message(:alert, t_flash_message(@comment)) %>
 <% end %>

--- a/app/views/issues/issue_detail/_main_form.html.erb
+++ b/app/views/issues/issue_detail/_main_form.html.erb
@@ -24,7 +24,7 @@
       </div>
     <% end %>
 
-    <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description") %>
+    <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description", readOnly: false) %>
     <%= f.hidden_field :description, class: "js-issue-description" %>
 
     <div class="flex gap-2 items-center justify-end">


### PR DESCRIPTION
This PR:

- Increases spacing for comments
- Shows comment actions only after the html is rendered. This way we can verify in the PRO Edition if the current user is the original author of the comment.