### PR TITLE
Enhancements to issue detail markdown field

### DIFF
--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -39,7 +39,7 @@
             } %>
       </div>
 
-      <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: "#new_issue_form .js-issue-description" ) %>
+      <%= react_component("MarkdownEditor", defaultValue: issue.description, mirrorInputTargetSelector: "#new_issue_form .js-issue-description" ) %>
       <%= f.hidden_field :description, class: "js-issue-description" %>
 
       <div class="flex gap-2 justify-center">

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -1,6 +1,7 @@
 
 <%= turbo_frame_tag 'new_issue_form' do %>
-<%= render_modal do %>
+<%= render_modal(inner_container_options: {
+    class: "max-h-screen w-full max-w-3xl relative cpy-issue-detail" }) do %>
   <div class="border-b border-background-200 pb-2 mb-4">
     <div class="flex items-center space-x-2">
       <div class="flex h-7 w-7 items-center justify-center rounded-lg bg-primary-500/10 p-1 text-primary-500 ">
@@ -38,7 +39,7 @@
             } %>
       </div>
 
-      <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description" ) %>
+      <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: "#new_issue_form .js-issue-description" ) %>
       <%= f.hidden_field :description, class: "js-issue-description" %>
 
       <div class="flex gap-2 justify-center">

--- a/app/views/issues/comments/_form.html.erb
+++ b/app/views/issues/comments/_form.html.erb
@@ -6,7 +6,7 @@
 <%= form_with model: comment, url: form_url, method: form_method,
   class: "flex flex-col gap-2" do |f| %>
 
-  <%= react_component("MarkdownEditor", defaultValue: comment.content, bindTarget: "input[data-comment-content='#{comment.id || 'new' }']") %>
+  <%= react_component("MarkdownEditor", defaultValue: comment.content, mirrorInputTargetSelector: "input[data-comment-content='#{comment.id || 'new' }']") %>
   <%= f.hidden_field :content, data: { "comment-content": (comment.id || "new") }, required: true %>
 
   <div class="flex gap-2 justify-end">

--- a/app/views/issues/issue_detail/_main_form.html.erb
+++ b/app/views/issues/issue_detail/_main_form.html.erb
@@ -24,8 +24,7 @@
       </div>
     <% end %>
 
-    <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: "[data-issue-detail-description-for-issue='#{issue.id}']", readOnly: false) %>
-    <%= f.hidden_field :description, data: { "issue-detail-description-for-issue": issue.id } %>
+    <%= react_component("IssueDetail/Description", content: issue.description, issueId: issue.id) %>
 
     <div class="flex gap-2 items-center justify-end">
       <a class="link-cancel text-xs" data-action="click->modal#close">

--- a/app/views/issues/issue_detail/_main_form.html.erb
+++ b/app/views/issues/issue_detail/_main_form.html.erb
@@ -24,8 +24,8 @@
       </div>
     <% end %>
 
-    <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: ".js-issue-description", readOnly: false) %>
-    <%= f.hidden_field :description, class: "js-issue-description" %>
+    <%= react_component("MarkdownEditor", defaultValue: issue.description, bindTarget: "[data-issue-detail-description-for-issue='#{issue.id}']", readOnly: false) %>
+    <%= f.hidden_field :description, data: { "issue-detail-description-for-issue": issue.id } %>
 
     <div class="flex gap-2 items-center justify-end">
       <a class="link-cancel text-xs" data-action="click->modal#close">

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -6,7 +6,7 @@ const Description = ({ content, issueId }) => {
 
   return (
     <React.Fragment>
-      <MarkdownEditor defaultValue={content} readOnly={false} bindTargetRef={hiddenFieldRef}/>
+      <MarkdownEditor defaultValue={content} readOnly={false} mirrorInputTargetRef={hiddenFieldRef}/>
       <input type="hidden" name="issue[description]" value={content ? content : ""} ref={hiddenFieldRef}/>
     </React.Fragment>
   )

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -1,0 +1,15 @@
+import React, { useRef } from "react"
+import MarkdownEditor from "../MarkdownEditor"
+
+const Description = ({ content, issueId }) => {
+  const hiddenFieldRef = useRef(null)
+
+  return (
+    <React.Fragment>
+      <MarkdownEditor defaultValue={content} readOnly={false} bindTargetRef={hiddenFieldRef}/>
+      <input type="hidden" name="issue[description]" value={content ? content : ""} ref={hiddenFieldRef}/>
+    </React.Fragment>
+  )
+}
+
+export default Description

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react"
+import React, { useState } from "react"
 
 import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react"
 import { Editor, rootCtx, defaultValueCtx, editorViewOptionsCtx, editorViewCtx } from "@milkdown/kit/core"
@@ -23,9 +23,11 @@ import configureTableBlock from './MarkdownEditor/configure/table-block'
 import configureImageBlock from './MarkdownEditor/configure/image-block'
 
 function MilkdownEditor(props) {
-  const editable = () => !props.readOnly;
 
   useEditor((root) => {
+    const readOnly = !!props.readOnly;
+    const editable = () => !readOnly;
+
     const editor = Editor.make()
       .config((ctx) => {
         ctx.set(rootCtx, root);
@@ -77,7 +79,7 @@ function MarkdownEditor(props) {
   return (
     <React.StrictMode>
       <MilkdownProvider>
-        <MilkdownEditor {...props}/>
+        <MilkdownEditor bindTarget={props.bindTarget} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
       </MilkdownProvider>
     </React.StrictMode>
   )

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -43,6 +43,12 @@ function MilkdownEditor(props) {
           })
         }
 
+        if (props.bindTargetRef) {
+          ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
+            props.bindTargetRef.current.value = markdown
+          })
+        }
+
         ctx.update(editorViewOptionsCtx, (prev) => ({
           ...prev,
           editable,
@@ -79,7 +85,7 @@ function MarkdownEditor(props) {
   return (
     <React.StrictMode>
       <MilkdownProvider>
-        <MilkdownEditor bindTarget={props.bindTarget} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
+        <MilkdownEditor bindTargetRef={props.bindTargetRef} bindTarget={props.bindTarget} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
       </MilkdownProvider>
     </React.StrictMode>
   )

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -61,7 +61,7 @@ function MilkdownEditor(props) {
       .use(trailing)
       .use(imageBlockComponent)
 
-      if (!props.readOnly) {
+      if (editable()) {
         editor.config(configureMenu).use(menu)
       }
 

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -36,16 +36,16 @@ function MilkdownEditor(props) {
           ctx.set(defaultValueCtx, props.defaultValue)
         }
 
-        if (props.bindTarget) {
-          const target = document.querySelector(props.bindTarget)
+        if (props.mirrorInputTargetSelector) {
+          const target = document.querySelector(props.mirrorInputTargetSelector)
           ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
             target.value = markdown
           })
         }
 
-        if (props.bindTargetRef) {
+        if (props.mirrorInputTargetRef) {
           ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
-            props.bindTargetRef.current.value = markdown
+            props.mirrorInputTargetRef.current.value = markdown
           })
         }
 
@@ -85,7 +85,7 @@ function MarkdownEditor(props) {
   return (
     <React.StrictMode>
       <MilkdownProvider>
-        <MilkdownEditor bindTargetRef={props.bindTargetRef} bindTarget={props.bindTarget} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
+        <MilkdownEditor mirrorInputTargetRef={props.mirrorInputTargetRef} mirrorInputTargetSelector={props.mirrorInputTargetSelector} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
       </MilkdownProvider>
     </React.StrictMode>
   )


### PR DESCRIPTION
The comments are rendered as a markdown editor (read only).

After this was implemented, a strange bug appeared where only the last markdown editor of the page rendered the header menu. 

This PR fixes that by creating a dedicated component for editing issues (this alone fixes the bug)

But additionally:
- I've changed the way that hidden inputs refs are handled also updates all 'markdown bindings' to have a more unique id or passing a ref to the input itself (if another React component is using the MarkdownEditor)
- Now that we have a dedicated IssueDetail editor we can make the description field read only and only turn to "editable" after the user clicks on it. Also it's possible to track changes and warn if the user tries to close the modal before submitting the changes

Before:
![image](https://github.com/user-attachments/assets/f6500812-449b-4421-a93e-dc832b62efbd)
