### PR TITLE
Changes issue description to be a "text only" by default

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -12,6 +12,17 @@ class IssuesController < ApplicationController
     end
   end
 
+  def update_description
+    # In the future, we can check for
+    # potential conflicts when multiple
+    # users are editing the same issue
+    # at the same time.
+    @issue = Issue.find(params[:id])
+    @issue.update(description: params[:description])
+
+    head :ok
+  end
+
   def archive
     @issue = Issue.find(params[:id])
     @issue.archive!

--- a/app/views/issues/_create.html.erb
+++ b/app/views/issues/_create.html.erb
@@ -1,7 +1,7 @@
 
 <%= turbo_frame_tag 'new_issue_form' do %>
 <%= render_modal(inner_container_options: {
-    class: "max-h-screen w-full max-w-3xl relative cpy-issue-detail" }) do %>
+    class: "max-h-screen w-full max-w-2xl relative cpy-issue-detail" }) do %>
   <div class="border-b border-background-200 pb-2 mb-4">
     <div class="flex items-center space-x-2">
       <div class="flex h-7 w-7 items-center justify-center rounded-lg bg-primary-500/10 p-1 text-primary-500 ">
@@ -23,7 +23,7 @@
 
       <div class="mb-4 flex flex-col items-stretch gap-2">
         <%= f.label :title, Issue.human_attribute_name(:title), class: "label-primary" %>
-        <%= f.text_field :title, autofocus: true, class: "input-primary" %>
+        <%= f.text_field :title, autofocus: true, required: true, class: "input-primary" %>
       </div>
 
       <div class="mb-4 cpy-by-labels-titles flex flex-col items-stretch gap-2">

--- a/app/views/issues/_files_drop.html.erb
+++ b/app/views/issues/_files_drop.html.erb
@@ -1,4 +1,4 @@
-<div class="mt-2 mb-2">
+<div class="mt-4 mb-2">
   <h3 class="text-lg font-medium text-readable-content-500">
     <span class="mr-1 text-readable-content-500/80"><%= icon_for(:files) %></span>
     <%= Issue.human_attribute_name(:files) %>

--- a/app/views/issues/issue_detail/_main_form.html.erb
+++ b/app/views/issues/issue_detail/_main_form.html.erb
@@ -26,14 +26,6 @@
 
     <%= react_component("IssueDetail/Description", content: issue.description, issueId: issue.id) %>
 
-    <div class="flex gap-2 items-center justify-end">
-      <a class="link-cancel text-xs" data-action="click->modal#close">
-        <%= t('actions.cancel') %>
-      </a>
-
-      <% text = issue.persisted? ? t('actions.save') : t('actions.create') %>
-      <%= f.button text, class: "btn-primary btn-sm" %>
-    </div>
   <% end %>
 
   <% if issue.persisted? %>

--- a/app/views/issues/issue_detail/_main_form.html.erb
+++ b/app/views/issues/issue_detail/_main_form.html.erb
@@ -23,10 +23,9 @@
               } %>
       </div>
     <% end %>
-
-    <%= react_component("IssueDetail/Description", content: issue.description, issueId: issue.id) %>
-
   <% end %>
+
+  <%= react_component("IssueDetail/Description", content: issue.description, issueId: issue.id) %>
 
   <% if issue.persisted? %>
     <%= render partial: 'issues/files_drop', locals: { issue: } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,7 @@ Rails.application.routes.draw do
 
   resources :issues, only: [ :destroy ] do
     member do
+      patch :update_description
       patch :pick_grouping
       put :archive
       put :unarchive

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -43,7 +43,7 @@ const Description = ({ content, issueId }) => {
           </a>
         )}
       </div>
-      <div className={ isEditing ? "" : "cursor-pointer" } onClick={() => { setIsEditing(true) }}>
+      <div className={ isEditing ? "" : "cursor-pointer cpy-issue-detail-description" } onClick={() => { setIsEditing(true) }}>
         <MarkdownEditor defaultValue={currentContent} readOnly={!isEditing} mirrorInputTargetRef={hiddenFieldRef}/>
         <input type="hidden" name="issue[description]" value={currentContent ? currentContent : ""} ref={hiddenFieldRef}/>
       </div>

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -1,14 +1,43 @@
-import React, { useRef } from "react"
+import React, { useRef, useState } from "react"
 import MarkdownEditor from "../MarkdownEditor"
+import { t } from "i18n.js.erb"
 
 const Description = ({ content, issueId }) => {
   const hiddenFieldRef = useRef(null)
+  const [isEditing, setIsEditing] = useState(false)
 
   return (
-    <React.Fragment>
-      <MarkdownEditor defaultValue={content} readOnly={false} mirrorInputTargetRef={hiddenFieldRef}/>
-      <input type="hidden" name="issue[description]" value={content ? content : ""} ref={hiddenFieldRef}/>
-    </React.Fragment>
+    <div>
+      <div class="mt-2 mb-2 flex items-center justify-between">
+        <h3 class="text-lg font-medium text-readable-content-500">
+          <span class="mr-1 text-readable-content-500/80">
+            <i class="fa-solid text-sm fa-align-justify"></i>
+          </span>
+          { t("activerecord.attributes.issue.description") }
+        </h3>
+
+        { !isEditing && (
+          <a className="btn-primary text-sm cursor-pointer btn-sm" onClick={() => { setIsEditing(true) }}>
+            { t("actions.edit") }
+          </a>
+        )}
+      </div>
+      <div onClick={() => { setIsEditing(true) }}>
+        <MarkdownEditor defaultValue={content} readOnly={!isEditing} mirrorInputTargetRef={hiddenFieldRef}/>
+        <input type="hidden" name="issue[description]" value={content ? content : ""} ref={hiddenFieldRef}/>
+      </div>
+      { isEditing && (
+        <div className="flex gap-4 items-center mt-2 justify-end">
+          <a className="link-cancel text-sm" onClick={() => { setIsEditing(false) }}>
+            { t("actions.cancel") }
+          </a>
+
+          <button className="btn-primary">
+            { t("actions.save") }
+          </button>
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -1,17 +1,38 @@
 import React, { useRef, useState } from "react"
 import MarkdownEditor from "../MarkdownEditor"
 import { t } from "i18n.js.erb"
+import { FetchRequest } from '@rails/request.js'
+import { updateDescriptionIssuePath } from 'routes.js.erb'
 
 const Description = ({ content, issueId }) => {
   const hiddenFieldRef = useRef(null)
   const [isEditing, setIsEditing] = useState(false)
+  const [currentContent, setCurrentContent] = useState(content)
+
+  const handleSave = (e) => {
+    e.preventDefault()
+
+    const request = new FetchRequest('patch', updateDescriptionIssuePath(issueId), {
+      body: JSON.stringify({ description: hiddenFieldRef.current.value }),
+      responseKind: 'turbo-stream'
+    }).perform()
+
+    request.then((response) => {
+      if (response.ok) {
+        setIsEditing(false)
+        setCurrentContent(hiddenFieldRef.current.value)
+      } else {
+        alert("Failed to update description")
+      }
+    })
+  }
 
   return (
-    <div>
-      <div class="mt-2 mb-2 flex items-center justify-between">
-        <h3 class="text-lg font-medium text-readable-content-500">
-          <span class="mr-1 text-readable-content-500/80">
-            <i class="fa-solid text-sm fa-align-justify"></i>
+    <form onSubmit={handleSave}>
+      <div className="mt-2 mb-2 flex items-center justify-between">
+        <h3 className="text-lg font-medium text-readable-content-500">
+          <span className="mr-1 text-readable-content-500/80">
+            <i className="fa-solid text-sm fa-align-justify"></i>
           </span>
           { t("activerecord.attributes.issue.description") }
         </h3>
@@ -22,9 +43,9 @@ const Description = ({ content, issueId }) => {
           </a>
         )}
       </div>
-      <div onClick={() => { setIsEditing(true) }}>
-        <MarkdownEditor defaultValue={content} readOnly={!isEditing} mirrorInputTargetRef={hiddenFieldRef}/>
-        <input type="hidden" name="issue[description]" value={content ? content : ""} ref={hiddenFieldRef}/>
+      <div className={ isEditing ? "" : "cursor-pointer" } onClick={() => { setIsEditing(true) }}>
+        <MarkdownEditor defaultValue={currentContent} readOnly={!isEditing} mirrorInputTargetRef={hiddenFieldRef}/>
+        <input type="hidden" name="issue[description]" value={currentContent ? currentContent : ""} ref={hiddenFieldRef}/>
       </div>
       { isEditing && (
         <div className="flex gap-4 items-center mt-2 justify-end">
@@ -32,12 +53,12 @@ const Description = ({ content, issueId }) => {
             { t("actions.cancel") }
           </a>
 
-          <button className="btn-primary">
+          <button type="submit" className="btn-primary">
             { t("actions.save") }
           </button>
         </div>
       )}
-    </div>
+    </form>
   )
 }
 

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -74,7 +74,7 @@ function MilkdownEditor(props) {
       }
 
       return editor
-  }, [])
+  }, [props.readOnly])
 
   return (
     <Milkdown />

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@milkdown-lab/plugin-menu": "^1.3.1",
     "@milkdown/kit": "^7.6.3",
     "@milkdown/react": "^7.6.3",
+    "@rails/request.js": "^0.0.12",
     "@types/babel__core": "^7.20.5",
     "@types/webpack": "^5.28.5",
     "atomico": "^1.79.2",

--- a/spec/features/project_management/all_issues/managing_issues_spec.rb
+++ b/spec/features/project_management/all_issues/managing_issues_spec.rb
@@ -147,9 +147,9 @@ describe 'As a project manager, I want to manage my issues from all issues' do
 
     within '#issue_detail' do
       fill_in :issue_title, with: "Updated title"
-    end
 
-    click_button "Save"
+      page.evaluate_script("document.querySelector('#issue_title').blur()")
+    end
 
     expect(page).to have_content("Issue was successfully updated.")
 

--- a/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
+++ b/spec/features/project_management/using_views/kanban/managing_issues_spec.rb
@@ -114,6 +114,7 @@ describe 'As a user, I want to manage my project using a kanban view' do
     end
 
     within '#issue_detail' do
+      find('.cpy-issue-detail-description').click
       fill_in :issue_title, with: "Updated title"
       write_in_md_editor_field(" appending description")
     end

--- a/yarn.lock
+++ b/yarn.lock
@@ -2270,6 +2270,11 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
+"@rails/request.js@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.12.tgz#3d1f73e7585141d9c4c2149a34476d128eb900bc"
+  integrity sha512-g3//JBja1s04Zflj7IoMLQuXza9i4ZvtLmm0r0dMwh1QQUs6rL2iKUOGGyERfLsd81SnXC5ucfVV//rtsDlEEA==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"


### PR DESCRIPTION
This PR improves the overall Issue Detail modal usability:

- Making the Description markdown component readonly at start
- If the user clicks on the field or on the edit button, it turns to editable mode
- If the user cancel the edit, it goes back to the old value
- If the user saves the edit, it updates the text only field

# Future
- I've created a specific 'update_coment' endpoint. It may help us in the future to deal with potential conflicts when more than one people update the description at the same time.

![description_edit](https://github.com/user-attachments/assets/e19c8417-baa2-4b81-800c-fbbd407cccb6)
