### PR TITLE
Fix issue with scroll into view for new cards

### DIFF
--- a/app/javascript/controllers/grouping_column_controller.js
+++ b/app/javascript/controllers/grouping_column_controller.js
@@ -42,17 +42,14 @@ export default class extends Controller {
   }
 
   cardTargetConnected(cardElement) {
-    // Only scrolls to card when adding via inline form
-    // and not when page is loaded (it would trigger for all cards)
-    if (this.isCardBeingCreated()) {
-      cardElement.scrollIntoView({ behavior: "instant", block: "end" })
+    if (this.isInlineCardFormOpen()) {
       this.inlineCardFormTitleTarget.value = ''
       // Needed because of resizable input
       this.inlineCardFormTitleTarget.dispatchEvent(new Event('input', { bubbles: true }));
     }
   }
 
-  isCardBeingCreated() {
+  isInlineCardFormOpen() {
     return !this.inlineCardFormTarget.classList.contains('hidden')
   }
 

--- a/app/views/visualizations/issues/create.turbo_stream.erb
+++ b/app/views/visualizations/issues/create.turbo_stream.erb
@@ -1,5 +1,6 @@
 <% if @issue.persisted? %>
   <%= turbo_stream.append "#{ @grouping.id }-cards-wrapper", partial: "visualizations/card", locals: {
+    scroll_on_connect: true,
     visualization: current_visualization,
     issue: @issue
   } %>


### PR DESCRIPTION
## Why?

This PR solves an issue where cards keep getting forced to scroll into view when it has some data updated

## Current behavior

When a card is created or updated it is always scrolled into view.

## Expected behavior

Card should only be scrolled into view when created ONLY for the session that created it. (Ex: When mutiple tabs open on the same board, only the board used to create the issue should scroll the issue into view)