### PR TITLE
Issue description storing temporary description

### DIFF
--- a/config/locales/frontend-components/issue_detail.en.yml
+++ b/config/locales/frontend-components/issue_detail.en.yml
@@ -1,0 +1,4 @@
+en:
+  issue_detail:
+    description:
+      changes_not_saved: "Changes not saved"

--- a/config/locales/frontend-components/issue_detail.en.yml
+++ b/config/locales/frontend-components/issue_detail.en.yml
@@ -2,3 +2,4 @@ en:
   issue_detail:
     description:
       changes_not_saved: "Changes not saved"
+      discard_changed: "Discard changes"

--- a/config/locales/frontend-components/issue_detail.pt-BR.yml
+++ b/config/locales/frontend-components/issue_detail.pt-BR.yml
@@ -2,3 +2,4 @@ pt-BR:
   issue_detail:
     description:
       changes_not_saved: "Alterações não salvas"
+      discard_changed: "Descartar alterações"

--- a/config/locales/frontend-components/issue_detail.pt-BR.yml
+++ b/config/locales/frontend-components/issue_detail.pt-BR.yml
@@ -1,0 +1,4 @@
+pt-BR:
+  issue_detail:
+    description:
+      changes_not_saved: "Alterações não salvas"

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -13,7 +13,7 @@ const Description = ({ content, issueId }) => {
   const [localState, setLocalState] = useLocalState(issueId)
   const [isEditing, setIsEditing] = useState(false)
   const [currentContent, setCurrentContent] = useState(content)
-  const defaultValue = localState || currentContent
+  const defaultValue = localState || currentContent || ""
 
   const handleSave = useCallback((e) => {
     e.preventDefault()
@@ -35,7 +35,9 @@ const Description = ({ content, issueId }) => {
   }, [hiddenFieldRef, setIsEditing, setCurrentContent, setLocalState])
 
   const handleInput = useCallback(value => {
-    if (value.trim() != currentContent.trim()) {
+    const persistedContent = currentContent || ""
+
+    if (value.trim() != persistedContent.trim()) {
       setLocalState(value)
     }
   }, [setLocalState])

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -35,7 +35,9 @@ const Description = ({ content, issueId }) => {
   }, [hiddenFieldRef, setIsEditing, setCurrentContent, setLocalState])
 
   const handleInput = useCallback(value => {
-    setLocalState(value)
+    if (value.trim() != currentContent.trim()) {
+      setLocalState(value)
+    }
   }, [setLocalState])
 
   const handleCancel = useCallback(() => {
@@ -80,7 +82,7 @@ const Description = ({ content, issueId }) => {
       { isEditing && (
         <div className="flex gap-4 items-center mt-2 justify-end">
           <a className="link-cancel text-sm" onClick={handleCancel}>
-            { t("actions.cancel") }
+            { localState ? t("issue_detail.description.discard_changed") : t("actions.cancel") }
           </a>
 
           <button type="submit" className="btn-primary">

--- a/frontend/components/IssueDetail/Description.js
+++ b/frontend/components/IssueDetail/Description.js
@@ -4,12 +4,18 @@ import { t } from "i18n.js.erb"
 import { FetchRequest } from '@rails/request.js'
 import { updateDescriptionIssuePath } from 'routes.js.erb'
 
+import useLocalState from 'utils/use-local-state'
+
+const { useEffect, useCallback } = React
+
 const Description = ({ content, issueId }) => {
   const hiddenFieldRef = useRef(null)
+  const [localState, setLocalState] = useLocalState(issueId)
   const [isEditing, setIsEditing] = useState(false)
   const [currentContent, setCurrentContent] = useState(content)
+  const defaultValue = localState || currentContent
 
-  const handleSave = (e) => {
+  const handleSave = useCallback((e) => {
     e.preventDefault()
 
     const request = new FetchRequest('patch', updateDescriptionIssuePath(issueId), {
@@ -21,11 +27,21 @@ const Description = ({ content, issueId }) => {
       if (response.ok) {
         setIsEditing(false)
         setCurrentContent(hiddenFieldRef.current.value)
+        setLocalState(null)
       } else {
         alert("Failed to update description")
       }
     })
-  }
+  }, [hiddenFieldRef, setIsEditing, setCurrentContent, setLocalState])
+
+  const handleInput = useCallback(value => {
+    setLocalState(value)
+  }, [setLocalState])
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false)
+    setLocalState(null)
+  }, [setIsEditing, setLocalState])
 
   return (
     <form onSubmit={handleSave}>
@@ -37,19 +53,33 @@ const Description = ({ content, issueId }) => {
           { t("activerecord.attributes.issue.description") }
         </h3>
 
-        { !isEditing && (
-          <a className="btn-primary text-sm cursor-pointer btn-sm" onClick={() => { setIsEditing(true) }}>
-            { t("actions.edit") }
-          </a>
-        )}
+        <div className="flex flex-row gap-2 items-center justify-between">
+          { localState && (
+            <a className="link-primary text-sm cursor-pointer btn-sm" onClick={() => { setIsEditing(true) }}>
+              { t("issue_detail.description.changes_not_saved") }
+            </a>
+          )}
+
+          { !isEditing && (
+            <a className="btn-primary text-sm cursor-pointer btn-sm" onClick={() => { setIsEditing(true) }}>
+              { t("actions.edit") }
+            </a>
+          )}
+        </div>
       </div>
       <div className={ isEditing ? "" : "cursor-pointer cpy-issue-detail-description" } onClick={() => { setIsEditing(true) }}>
-        <MarkdownEditor defaultValue={currentContent} readOnly={!isEditing} mirrorInputTargetRef={hiddenFieldRef}/>
-        <input type="hidden" name="issue[description]" value={currentContent ? currentContent : ""} ref={hiddenFieldRef}/>
+        <MarkdownEditor
+          defaultValue={defaultValue}
+          readOnly={!isEditing}
+          mirrorInputTargetRef={hiddenFieldRef}
+          identifier={issueId}
+          onInput={handleInput}
+          />
+        <input type="hidden" name="issue[description]" value={defaultValue} ref={hiddenFieldRef}/>
       </div>
       { isEditing && (
         <div className="flex gap-4 items-center mt-2 justify-end">
-          <a className="link-cancel text-sm" onClick={() => { setIsEditing(false) }}>
+          <a className="link-cancel text-sm" onClick={handleCancel}>
             { t("actions.cancel") }
           </a>
 

--- a/frontend/components/MarkdownEditor.js
+++ b/frontend/components/MarkdownEditor.js
@@ -22,7 +22,21 @@ import configureLinkTooltip from './MarkdownEditor/configure/link-tooltip'
 import configureTableBlock from './MarkdownEditor/configure/table-block'
 import configureImageBlock from './MarkdownEditor/configure/image-block'
 
-function MilkdownEditor(props) {
+const { useCallback } = React
+
+function MilkdownEditor({ mirrorInputTargetSelector, mirrorInputTargetRef, onInput = () => {}, ...props }) {
+  const handleMarkdownUpdate = useCallback((_ctx, markdown, _prevMarkdown) => {
+    if (mirrorInputTargetSelector) {
+      const target = document.querySelector(mirrorInputTargetSelector)
+      target.value = markdown
+    }
+
+    if (mirrorInputTargetRef) {
+      mirrorInputTargetRef.current.value = markdown
+    }
+
+    onInput(markdown)
+  }, [mirrorInputTargetSelector, mirrorInputTargetRef, onInput])
 
   useEditor((root) => {
     const readOnly = !!props.readOnly;
@@ -36,18 +50,7 @@ function MilkdownEditor(props) {
           ctx.set(defaultValueCtx, props.defaultValue)
         }
 
-        if (props.mirrorInputTargetSelector) {
-          const target = document.querySelector(props.mirrorInputTargetSelector)
-          ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
-            target.value = markdown
-          })
-        }
-
-        if (props.mirrorInputTargetRef) {
-          ctx.get(listenerCtx).markdownUpdated((ctx, markdown, prevMarkdown) => {
-            props.mirrorInputTargetRef.current.value = markdown
-          })
-        }
+        ctx.get(listenerCtx).markdownUpdated(handleMarkdownUpdate)
 
         ctx.update(editorViewOptionsCtx, (prev) => ({
           ...prev,
@@ -85,7 +88,7 @@ function MarkdownEditor(props) {
   return (
     <React.StrictMode>
       <MilkdownProvider>
-        <MilkdownEditor mirrorInputTargetRef={props.mirrorInputTargetRef} mirrorInputTargetSelector={props.mirrorInputTargetSelector} defaultValue={props.defaultValue} readOnly={props.readOnly}/>
+        <MilkdownEditor {...props} />
       </MilkdownProvider>
     </React.StrictMode>
   )

--- a/frontend/shared/utils/use-local-state.js
+++ b/frontend/shared/utils/use-local-state.js
@@ -1,0 +1,23 @@
+import React from 'react'
+
+const { useState, useEffect, useCallback } = React
+
+export default function useLocalState(identifier) {
+  const [state, setLocalState] = useState(null)
+
+  useEffect(() => {
+    const value = localStorage.getItem(identifier)
+
+    if (!value) return
+
+    setLocalState(JSON.parse(value))
+  }, [identifier])
+
+
+  const setState = useCallback(value => {
+    localStorage.setItem(identifier, JSON.stringify(value))
+    setLocalState(value)
+  }, [setLocalState, identifier])
+
+  return [state, setState]
+}


### PR DESCRIPTION
## Why?

It happens with everybody. I am positive it already happened with you too...

While writing about very important on a website, after checking for every spell mistake, when everything looks fine and all, for some reason you close the tab and lost everything.

Maybe it was a misclick? Maybe the energy went off? Who knows?

When that happens, all we can do is smile... Smile like this person

![image](https://github.com/user-attachments/assets/580f2709-ac9c-4a34-a2a4-6aa369861e43)

So this PR help us avoid smiling like that by storing temporary changes on the issue details locally, so we can go back and actually save the descriptions we were writing.

## Preview

![record](https://github.com/user-attachments/assets/f6311867-c847-4979-8d6f-391c48c8b4b5)

Changes as discarded when cancelling the editing

![record](https://github.com/user-attachments/assets/60c47096-25fa-4cc9-9ec1-d5884e4a3f56)