### PR TITLE
Style due date based on the finished state

### DIFF
--- a/app/assets/tailwind/themes/_components/issue/card.css
+++ b/app/assets/tailwind/themes/_components/issue/card.css
@@ -14,6 +14,10 @@
 
     @apply group-hover:opacity-100;
     @apply peer-checked:opacity-100;
+
+    .fa-check {
+      font-size: 0.65rem;
+    }
   }
 
   .issue--card-due-date.finished {

--- a/app/assets/tailwind/themes/_components/issue/card.css
+++ b/app/assets/tailwind/themes/_components/issue/card.css
@@ -15,4 +15,12 @@
     @apply group-hover:opacity-100;
     @apply peer-checked:opacity-100;
   }
+
+  .issue--card-due-date {
+    @apply transition-all duration-300;
+
+    &.finished {
+      @apply text-success-500;
+    }
+  }
 }

--- a/app/assets/tailwind/themes/_components/issue/card.css
+++ b/app/assets/tailwind/themes/_components/issue/card.css
@@ -16,11 +16,7 @@
     @apply peer-checked:opacity-100;
   }
 
-  .issue--card-due-date {
-    @apply transition-all duration-300;
-
-    &.finished {
-      @apply text-success-500;
-    }
+  .issue--card-due-date.finished {
+    @apply hidden;
   }
 }

--- a/app/helpers/application_helper/due_date.rb
+++ b/app/helpers/application_helper/due_date.rb
@@ -4,7 +4,10 @@ module ApplicationHelper
       return unless issue.due_date?
 
       options = {
-        class: due_date_color_class_for(issue).to_s + " text-xs"
+        class: due_date_color_class_for(issue).to_s + " text-xs issue--card-due-date #{issue.finished? ? 'finished' : ''}",
+        data: {
+          visualization__board__card_target: "dueDate"
+        }
       }
 
       content_tag(:span, options) do

--- a/app/helpers/application_helper/issues.rb
+++ b/app/helpers/application_helper/issues.rb
@@ -26,6 +26,7 @@ module ApplicationHelper
         class: wrapper_class,
         data: {
           controller: "issue--finish-check",
+          action: "issue--finish-check:checked->visualization--board--card#onFinished issue--finish-check:unchecked->visualization--board--card#onUnfinished",
           issue__finish_check_finish_path_value: finish_issue_path(issue),
           issue__finish_check_unfinish_path_value: unfinish_issue_path(issue)
         }

--- a/app/javascript/controllers/visualization/board/card_controller.js
+++ b/app/javascript/controllers/visualization/board/card_controller.js
@@ -1,6 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
+  static targets = ['dueDate']
   static values = {
     scrollOnConnect: Boolean
   }
@@ -9,5 +10,13 @@ export default class extends Controller {
     if (this.scrollOnConnectValue) {
       this.element.scrollIntoView({ behavior: "smooth", block: "end" })
     }
+  }
+
+  onFinished() {
+    this.dueDateTarget.classList.add("finished")
+  }
+
+  onUnfinished() {
+    this.dueDateTarget.classList.remove("finished")
   }
 }


### PR DESCRIPTION
## Why?

After finishing the https://github.com/Eigenfocus/eigenfocus/pull/217, we notice we forgot to update the due date based on the issue been finished or not.

So this PR fixes that

## Preview

![record](https://github.com/user-attachments/assets/82dcc771-c13c-4206-ac1c-b7efaa48ea3a)

