### PR TITLE
Disable popover content hover

### DIFF
--- a/app/assets/tailwind/themes/_components/popover.css
+++ b/app/assets/tailwind/themes/_components/popover.css
@@ -3,6 +3,7 @@
 
   .popover__content {
     @apply absolute;
+    @apply pointer-events-none;
     @apply text-sm;
     @apply bg-background-100 rounded-lg py-1 px-2;
     @apply transition-opacity duration-500;


### PR DESCRIPTION
## Why?

As we change the popover style from display:none to opacity: 0% for better transition, even hidden, the element could still be hovered, making it appear.

To avoid that, this PR disable pointer events, so hover doesn't trigger on popover content