### PR TITLE
Issue UI adjustments for "Mark as finished"

### DIFF
--- a/app/assets/tailwind/themes/_components/issue/all.css
+++ b/app/assets/tailwind/themes/_components/issue/all.css
@@ -1,2 +1,2 @@
 @import "./card";
-@import "./finish-check";
+@import "./finish-toogle";

--- a/app/assets/tailwind/themes/_components/issue/card.css
+++ b/app/assets/tailwind/themes/_components/issue/card.css
@@ -3,21 +3,10 @@
 
   .issue--title {
     @apply transition-all duration-300;
-    @apply -translate-x-6 -mr-6;
-
-    @apply group-hover:translate-x-0 group-hover:mr-0;
-    @apply peer-checked:translate-x-0 peer-checked:mr-0;
   }
 
-  .issue--finish-check {
-    @apply opacity-0;
+  .issue--finish-toggle {
 
-    @apply group-hover:opacity-100;
-    @apply peer-checked:opacity-100;
-
-    .fa-check {
-      font-size: 0.65rem;
-    }
   }
 
   .issue--card-due-date.finished {

--- a/app/assets/tailwind/themes/_components/issue/card.css
+++ b/app/assets/tailwind/themes/_components/issue/card.css
@@ -5,8 +5,25 @@
     @apply transition-all duration-300;
   }
 
-  .issue--finish-toggle {
+  .issue--finish-toggle-wrapper {
+    @apply transition-all duration-300;
 
+    width: 0;
+    opacity: 0;
+
+    &:has(.finished) {
+      @apply mr-1;
+      opacity: 1;
+      width: 1.2rem;
+    }
+  }
+
+  &:hover {
+    .issue--finish-toggle-wrapper {
+      @apply mr-1;
+      width: 1.2rem;
+      opacity: 1;
+    }
   }
 
   .issue--card-due-date.finished {

--- a/app/assets/tailwind/themes/_components/issue/finish-toogle.css
+++ b/app/assets/tailwind/themes/_components/issue/finish-toogle.css
@@ -1,27 +1,12 @@
-.issue--finish-check {
-  @apply block shrink-0 cursor-pointer;
-  @apply flex justify-center items-center;
-  @apply border-2 border-background-600 rounded-full;
-  @apply text-xs;
-  @apply transition-all duration-300;
-
-  @apply hover:border-background-800;
-  @apply peer-checked:bg-success-300 peer-checked:border-success-300;
-  @apply peer-checked:hover:bg-success-500 peer-checked:hover:border-success-500;
-
-  i {
-    @apply absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2;
-    @apply relative w-full h-full;
-    @apply transition-opacity duration-300;
-  }
-}
-
 .issue--finish-toggle {
   @apply rounded-full border-readable-content-500/60 border-2 text-readable-content-500 transition-all duration-300;
   @apply flex items-center justify-center;
+  @apply cursor-pointer;
 
   height: 1.2rem;
   width: 1.2rem;
+  min-height: 1.2rem;
+  min-width: 1.2rem;
 
   font-size: 0.65rem;
 

--- a/app/assets/tailwind/themes/_components/issue/finish-toogle.css
+++ b/app/assets/tailwind/themes/_components/issue/finish-toogle.css
@@ -15,3 +15,26 @@
     @apply transition-opacity duration-300;
   }
 }
+
+.issue--finish-toggle {
+  @apply rounded-full border-readable-content-500/60 border-2 text-readable-content-500 transition-all duration-300;
+  @apply flex items-center justify-center;
+
+  height: 1.2rem;
+  min-height: 1.2rem;
+  width: 1.2rem;
+  min-width: 1.2rem;
+  font-size: 0.65rem;
+
+  .finish-icon {
+    display: none;
+  }
+
+  &.finished {
+    @apply bg-success-200 text-success-700 border-success-200;
+
+    .finish-icon {
+      display: inline-block;
+    }
+  }
+}

--- a/app/assets/tailwind/themes/_components/issue/finish-toogle.css
+++ b/app/assets/tailwind/themes/_components/issue/finish-toogle.css
@@ -21,9 +21,8 @@
   @apply flex items-center justify-center;
 
   height: 1.2rem;
-  min-height: 1.2rem;
   width: 1.2rem;
-  min-width: 1.2rem;
+
   font-size: 0.65rem;
 
   .finish-icon {

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -41,12 +41,10 @@ class IssuesController < ApplicationController
   def finish
     @issue = Issue.find(params[:id])
     @issue.finish!
-    render_turbo_alert_message("notice", t_flash_message(@issue))
   end
 
   def unfinish
     @issue = Issue.find(params[:id])
     @issue.unfinish!
-    render_turbo_alert_message("notice", t_flash_message(@issue))
   end
 end

--- a/app/helpers/application_helper/issues.rb
+++ b/app/helpers/application_helper/issues.rb
@@ -20,41 +20,5 @@ module ApplicationHelper
         )
       end
     end
-
-    def issue_finish_check(issue, wrapper_class: "", checkbox_class: "", icon_class: "", insert_after: false, &block)
-      wrapper_options = {
-        class: wrapper_class,
-        data: {
-          controller: "issue--finish-check",
-          action: "issue--finish-check:checked->visualization--board--card#onFinished issue--finish-check:unchecked->visualization--board--card#onUnfinished",
-          issue__finish_check_finish_path_value: finish_issue_path(issue),
-          issue__finish_check_unfinish_path_value: unfinish_issue_path(issue)
-        }
-      }
-
-      checkbox_options = {
-        class: "issue--finish-check group/check cpy-finish-check-toogle #{checkbox_class}",
-        data: {
-          controller: "animation",
-          action: "click->issue--finish-check#toogle:prevent issue--finish-check:checked->animation#zoomIn issue--finish-check:unchecked->animation#zoomOut",
-          animation_speed_value: "faster"
-        }
-      }
-
-      content_tag(:div, wrapper_options) do
-        concat(capture(&block)) if insert_after
-
-        concat(
-          content_tag(:input, nil, type: "checkbox", class: "peer sr-only hidden", checked: issue.finished?, data: { issue__finish_check_target: "checkbox" })
-        )
-        concat(
-          content_tag(:div, checkbox_options) do
-            content_tag(:i, nil, class: "fa fa-check opacity-0 peer-checked:group-[]/check:opacity-100 #{icon_class}", data: { animation_target: "animatable" })
-          end
-        )
-
-        concat(capture(&block)) unless insert_after
-      end
-    end
   end
 end

--- a/app/javascript/controllers/issue/finish_toogle_controller.js
+++ b/app/javascript/controllers/issue/finish_toogle_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+import { FetchRequest } from '@rails/request.js'
+
+export default class extends Controller {
+  static values = {
+    finishPath: { type: String },
+    unfinishPath: { type: String },
+  }
+
+  toogle(e) {
+    e.preventDefault()
+    if (this.element.classList.contains("finished")) {
+      this.markAsUnchecked()
+    } else {
+      this.markAsChecked()
+    }
+  }
+
+  markAsChecked() {
+    this.element.classList.add("finished")
+    this.dispatch("checked")
+    this.#request(this.finishPathValue)
+  }
+
+  markAsUnchecked() {
+    this.element.classList.remove("finished")
+    this.dispatch("unchecked")
+    this.#request(this.unfinishPathValue)
+  }
+
+  #request(path) {
+    const request = new FetchRequest('put', path)
+
+    return request.perform()
+  }
+}

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -27,7 +27,7 @@
         <%= global_issue_link(issue) %>
       </div>
       <div class="flex flex-row items-center mb-1 flex-nowrap">
-        <div class="mr-2 issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
+        <div class="mr-2 issue--finish-toggle cpy-finish-check-toogle <%= issue.finished? ? 'finished' : '' %>"
           data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
           data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
           data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
@@ -47,7 +47,7 @@
             }
             }) do |f| %>
 
-            <div data-controller='resizable-input' class="w-full relative" >
+            <div data-controller='resizable-input' class="w-full cpy-issue-detail-title relative" >
               <div data-resizable-input-target="replica" class="break-all text-xl font-bold text-readable-content-600 p-1 pt-1 -ml-2 whitespace-pre-line"></div>
 
               <%= f.text_area :title, required: true,

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -23,16 +23,21 @@
         </div>
       <% end %>
 
-      <div class="mb-1">
+      <div class="">
         <%= global_issue_link(issue) %>
       </div>
-      <div class="flex flex-col items-center">
-        <%= issue_finish_check(
-          issue,
-          wrapper_class: "flex flex-row justify-stretch w-full gap-2 cpy-issue-detail-title",
-          checkbox_class: "size-6",
-          icon_class: "text-sm"
-        ) do %>
+      <div class="flex flex-row items-center mb-1 flex-nowrap">
+        <div class="mr-2 issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
+          data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
+          data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
+          data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
+
+          <div class="finish-icon">
+            <i class="fa fa-check text-green-500"></i>
+          </div>
+        </div>
+
+        <div class="flex grow">
           <%= form_with(model: issue, url: local_assigns[:form_path], html: {
             class: 'w-full flex justify-stretch',
             data: {
@@ -43,7 +48,7 @@
             }) do |f| %>
 
             <div data-controller='resizable-input' class="w-full relative" >
-              <div data-resizable-input-target="replica" class="break-all text-xl font-bold text-readable-content-600 p-2 pt-1 -ml-2 whitespace-pre-line"></div>
+              <div data-resizable-input-target="replica" class="break-all text-xl font-bold text-readable-content-600 p-1 pt-1 -ml-2 whitespace-pre-line"></div>
 
               <%= f.text_area :title, required: true,
                 class: "issue-detail-title-input -ml-2 min-h-8",
@@ -53,7 +58,7 @@
                 %>
             </div>
           <% end %>
-        <% end %>
+        </div>
       </div>
       <div class="flex flex-col md:flex-row gap-8" data-controller="dropzone" data-action="dropzone:complete->issue-detail#fileUploadCompleted">
         <div class="flex flex-col w-full md:w-3/4">

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -23,14 +23,14 @@
         </div>
       <% end %>
 
-      <div class="flex flex-col">
-        <div class="mb-1">
-          <%= global_issue_link(issue) %>
-        </div>
+      <div class="mb-1">
+        <%= global_issue_link(issue) %>
+      </div>
+      <div class="flex flex-col items-center">
         <%= issue_finish_check(
           issue,
           wrapper_class: "flex flex-row justify-stretch w-full gap-2 cpy-issue-detail-title",
-          checkbox_class: "size-6 mt-1",
+          checkbox_class: "size-6",
           icon_class: "text-sm"
         ) do %>
           <%= form_with(model: issue, url: local_assigns[:form_path], html: {

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -24,7 +24,7 @@
       <% end %>
 
       <div class="flex flex-col">
-        <div>
+        <div class="mb-1">
           <%= global_issue_link(issue) %>
         </div>
         <%= issue_finish_check(

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -18,14 +18,16 @@
     </div>
 
 
-    <div class="flex gap-1 flex-nowrap">
-      <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
-        data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
-        data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
-        data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
+    <div class="flex flex-nowrap">
+      <div class="issue--finish-toggle-wrapper">
+        <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
+          data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
+          data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
+          data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
 
-        <div class="finish-icon">
-          <i class="fa fa-check text-green-500"></i>
+          <div class="finish-icon">
+            <i class="fa fa-check text-green-500"></i>
+          </div>
         </div>
       </div>
 

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -17,11 +17,23 @@
       <i class="fa fa-pencil"></i>
     </div>
 
-    <%= issue_finish_check(issue, wrapper_class: "flex flex-row gap-2", checkbox_class: "size-4", icon_class: "text-xs" ) do %>
+
+    <div class="flex gap-1 flex-nowrap">
+      <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
+        data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
+        data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
+        data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
+
+        <div class="finish-icon">
+          <i class="fa fa-check text-green-500"></i>
+        </div>
+      </div>
+
       <p class="issue--title font-normal grow break-all" data-issue-title>
         <%= issue.title %>
       </p>
-    <% end %>
+    </div>
+
 
     <%= labels_list_for(issue) %>
 

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -20,7 +20,7 @@
 
     <div class="flex flex-nowrap">
       <div class="issue--finish-toggle-wrapper">
-        <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %>"
+        <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %> cpy-finish-check-toogle"
           data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
           data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
           data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">

--- a/spec/features/issues/mark_as_finished_spec.rb
+++ b/spec/features/issues/mark_as_finished_spec.rb
@@ -14,7 +14,7 @@ describe "Issues - Mark as finished" do
 
       find(".cpy-finish-check-toogle").click
 
-      expect(page).to have_content("Issue was successfully marked as finished.")
+      expect(page).to have_css(".cpy-finish-check-toogle.finished")
       expect(issue.reload).to be_finished
     end
   end
@@ -27,7 +27,7 @@ describe "Issues - Mark as finished" do
 
       find(".cpy-finish-check-toogle").click
 
-      expect(page).to have_content("Issue was successfully unmarked as finished.")
+      expect(page).to_not have_css(".cpy-finish-check-toogle.finished")
       expect(issue.reload).to_not be_finished
     end
   end

--- a/spec/features/project_management/using_views/kanban/mark_as_finished_spec.rb
+++ b/spec/features/project_management/using_views/kanban/mark_as_finished_spec.rb
@@ -23,7 +23,7 @@ describe "Issues - Mark as finished" do
         find(".cpy-finish-check-toogle").click
       end
 
-      expect(page).to have_content("Issue was successfully marked as finished.")
+      expect(page).to have_css(".cpy-finish-check-toogle.finished")
       expect(issue.reload).to be_finished
     end
   end
@@ -40,7 +40,7 @@ describe "Issues - Mark as finished" do
         find(".cpy-finish-check-toogle").click
       end
 
-      expect(page).to have_content("Issue was successfully unmarked as finished.")
+      expect(page).to_not have_css(".cpy-finish-check-toogle.finished")
       expect(issue.reload).to_not be_finished
     end
   end


### PR DESCRIPTION
This PR:

- Refactor the "issue finished check" to a "Issue finish toggle" concept
- Refactor `_card` partial to:
  -  just use a normal div with the stimulus controller attached instead of a helper
  - be independent of the "issue-finished-toggle" component by animating a wrapper and not the toggle itself
- Refactor the `issue_detail`:
  - To make the "finished toggle" and the "title input" independent of each other. The old implementation was using a helper and a block containing the title input. It was a little confusing what was happening there as this is not needed...
- Refactor the way that things are animated when a card is hovered to not be dependent on JS
- Adjusts margins, alignments and sizes for the card and issue detail title/finished toggle
- Removes alert messages for "finish/unfinish" actions

In a future PR:

Consider using ViewComponents to modularize this part or create a React Component (probably the best approach as it will be needed the PRO Edition...)

![image](https://github.com/user-attachments/assets/79757e91-cc45-4bfd-b654-a06f2fa663f7)

![image](https://github.com/user-attachments/assets/82e52dad-b273-4705-8a1e-e99837b11b35)
