### PR TITLE
ref: changes issue finish toggle to use view_component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ gem "shakapacker", "~> 8.2"
 gem "react-rails", "~> 3.2"
 gem "js-routes", "~> 2.3"
 gem "i18n-js", "~> 4.2"
+gem "view_component", "4.0.0.rc5"
 
 # For configuration files
 gem "dry-struct", "~> 1.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,6 +453,9 @@ GEM
     unicode-emoji (4.0.4)
     uri (1.0.3)
     useragent (0.16.11)
+    view_component (4.0.0.rc5)
+      activesupport (>= 7.1.0, < 8.1)
+      concurrent-ruby (~> 1)
     web-console (4.2.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -523,6 +526,7 @@ DEPENDENCIES
   timecop
   turbo-rails
   tzinfo-data
+  view_component (= 4.0.0.rc5)
   web-console
   webmock
 

--- a/app/components/issue/finish_toggle_component.html.erb
+++ b/app/components/issue/finish_toggle_component.html.erb
@@ -1,0 +1,11 @@
+<div class="issue--finish-toggle-wrapper">
+  <div class="issue--finish-toggle <%= @issue.finished? ? 'finished' : '' %> cpy-finish-check-toogle"
+    data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
+    data-issue--finish-toogle-finish-path-value="<%= helpers.finish_issue_path(issue) %>"
+    data-issue--finish-toogle-unfinish-path-value="<%= helpers.unfinish_issue_path(issue) %>">
+
+    <div class="finish-icon">
+      <i class="fa fa-check text-green-500"></i>
+    </div>
+  </div>
+</div>

--- a/app/components/issue/finish_toggle_component.html.erb
+++ b/app/components/issue/finish_toggle_component.html.erb
@@ -1,8 +1,8 @@
 <div class="issue--finish-toggle-wrapper">
   <div class="issue--finish-toggle <%= @issue.finished? ? 'finished' : '' %> cpy-finish-check-toogle"
     data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
-    data-issue--finish-toogle-finish-path-value="<%= helpers.finish_issue_path(issue) %>"
-    data-issue--finish-toogle-unfinish-path-value="<%= helpers.unfinish_issue_path(issue) %>">
+    data-issue--finish-toogle-finish-path-value="<%= helpers.finish_issue_path(@issue) %>"
+    data-issue--finish-toogle-unfinish-path-value="<%= helpers.unfinish_issue_path(@issue) %>">
 
     <div class="finish-icon">
       <i class="fa fa-check text-green-500"></i>

--- a/app/components/issue/finish_toggle_component.rb
+++ b/app/components/issue/finish_toggle_component.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Issue::FinishToggleComponent < ViewComponent::Base
+  attr_reader :issue
+
+  def initialize(issue:)
+    @issue = issue
+  end
+end

--- a/app/components/issue/finish_toggle_component.rb
+++ b/app/components/issue/finish_toggle_component.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Issue::FinishToggleComponent < ViewComponent::Base
-  attr_reader :issue
-
   def initialize(issue:)
     @issue = issue
   end

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -26,16 +26,8 @@
       <div class="flex justify-between items-center">
         <%= global_issue_link(issue) %>
       </div>
-      <div class="flex flex-row items-center flex-nowrap">
-        <div class="mr-2 issue--finish-toggle cpy-finish-check-toogle <%= issue.finished? ? 'finished' : '' %>"
-          data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
-          data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
-          data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
-
-          <div class="finish-icon">
-            <i class="fa fa-check text-green-500"></i>
-          </div>
-        </div>
+      <div class="flex flex-row items-center flex-nowrap gap-2">
+        <%= render(Issue::FinishToggleComponent.new(issue: issue)) %>
 
         <div class="flex grow">
           <%= form_with(model: issue, url: local_assigns[:form_path], html: {

--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -19,17 +19,7 @@
 
 
     <div class="flex flex-nowrap">
-      <div class="issue--finish-toggle-wrapper">
-        <div class="issue--finish-toggle <%= issue.finished? ? 'finished' : '' %> cpy-finish-check-toogle"
-          data-controller="issue--finish-toogle" data-action="click->issue--finish-toogle#toogle"
-          data-issue--finish-toogle-finish-path-value="<%= finish_issue_path(issue) %>"
-          data-issue--finish-toogle-unfinish-path-value="<%= unfinish_issue_path(issue) %>">
-
-          <div class="finish-icon">
-            <i class="fa fa-check text-green-500"></i>
-          </div>
-        </div>
-      </div>
+      <%= render(Issue::FinishToggleComponent.new(issue: issue)) %>
 
       <p class="issue--title font-normal grow break-all" data-issue-title>
         <%= issue.title %>

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -59,6 +59,7 @@ en:
         due_date: 'Due date'
         grouping: 'Column'
         comments: 'Comments'
+        finished_at: 'Finished at'
 
       issue_label:
         title: 'Title'

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -59,6 +59,7 @@ pt-BR:
         due_date: 'Data de encerramento'
         grouping: 'Coluna'
         comments: 'Comentários'
+        finished_at: 'Finalizada em'
 
       issue_label:
         title: 'Título'


### PR DESCRIPTION
This PR extracts the issue finish toggle to a view component and changes the issue detail and the card to use it.
 
In the PRO Version the toggle already is a React component (Board and GRID). 

Here I decided to go with a Rails view component because more components will be added in the future and keep things simple for this FREE version.

Bonus: I've added a missing translation for the issue `finished_at` attribute
