### PR TITLE
Custom input format for logged time in time entries

### DIFF
--- a/app/assets/tailwind/themes/_components/all.css
+++ b/app/assets/tailwind/themes/_components/all.css
@@ -11,3 +11,4 @@
 @import "./input";
 @import "./popover";
 @import "./issue/all";
+@import "./tab";

--- a/app/assets/tailwind/themes/_components/tab.css
+++ b/app/assets/tailwind/themes/_components/tab.css
@@ -1,0 +1,12 @@
+.tab-item {
+  @apply rounded-full border hover:border-primary-500 hover:text-primary-500 hover:bg-primary-500/10 text-readable-content-500 border-readable-content-500;
+
+  &.tab-item-xs {
+    @apply px-3 py-1 text-xs;
+  }
+
+  &.tab-item.tab-item--active {
+    @apply border-primary-700 text-primary-700 bg-primary-500/10;
+    cursor: default;
+  }
+}

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,6 +21,15 @@ class ProfilesController < ApplicationController
     end
   end
 
+  def update_preferences
+    if params[:time_entry_time_format].present?
+      current_user.preferences.time_entry_time_format = params[:time_entry_time_format]
+      current_user.preferences.save!
+    end
+
+    head :ok
+  end
+
   def user_params
     params.require(:profile).permit(:timezone, :locale)
   end

--- a/app/javascript/controllers/time_entry/time_input_formatter_controller.js
+++ b/app/javascript/controllers/time_entry/time_input_formatter_controller.js
@@ -1,0 +1,75 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["input", "placeholder", "tab"]
+  static values = { format: String }
+
+  connect() {
+    this.updatePlaceholderValue()
+    this.updatePlaceholderSettings()
+    this.setupEventListeners()
+  }
+
+  setupEventListeners() {
+    this.placeholderTarget.addEventListener('input', this.handlePlaceholderInput.bind(this))
+  }
+
+  selectFormat(event) {
+    const format = event.currentTarget.dataset.format
+    this.formatValue = format
+    this.updateTabs()
+    this.updatePlaceholderValue()
+    this.updatePlaceholderSettings()
+  }
+
+  updatePlaceholderSettings() {
+    switch (this.formatValue) {
+      case 'hours':
+        this.placeholderTarget.type = 'number'
+        this.placeholderTarget.step = '0.01'
+        this.placeholderTarget.min = '0'
+        break
+      default:
+        this.placeholderTarget.type = 'number'
+        this.placeholderTarget.step = '1'
+        this.placeholderTarget.min = '0'
+    }
+  }
+
+  updateTabs() {
+    this.tabTargets.forEach(tab => {
+      const isActive = tab.dataset.format === this.formatValue
+      tab.classList.toggle('tab-item--active', isActive)
+    })
+  }
+
+  updatePlaceholderValue() {
+    const minutes = parseInt(this.inputTarget.value) || 0
+    let displayValue = ''
+
+    switch (this.formatValue) {
+      case 'hours':
+        displayValue = (minutes / 60).toFixed(2)
+        break
+      default:
+        displayValue = minutes.toString()
+    }
+
+    this.placeholderTarget.value = displayValue
+  }
+
+  handlePlaceholderInput(event) {
+    const value = event.target.value
+    let minutes = 0
+
+    switch (this.formatValue) {
+      case 'hours':
+        minutes = Math.round(parseFloat(value) * 60)
+        break
+      default:
+        minutes = parseInt(value) || 0
+    }
+
+    this.inputTarget.value = minutes
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Relations
   has_many :time_entries
+  has_one :preferences, class_name: "User::Preferences"
 
   # Validations
   VALID_THEME_KEYS = TailwindTheme.all.map { |t| t.key }
@@ -17,6 +18,7 @@ class User < ApplicationRecord
     inclusion: { in:  ActiveSupport::TimeZone.all.map(&:name) },
     if: -> { timezone.present? }
 
+
   def is_profile_complete?
     locale.present? and
     timezone.present?
@@ -28,5 +30,9 @@ class User < ApplicationRecord
     # so we keep it here on the user model
     saved_theme_key = super
     saved_theme_key.blank? ? "amethyst-moon" : saved_theme_key
+  end
+
+  def preferences
+    super || build_preferences
   end
 end

--- a/app/models/user/preferences.rb
+++ b/app/models/user/preferences.rb
@@ -1,0 +1,5 @@
+class User::Preferences < ApplicationRecord
+  belongs_to :user
+
+  validates :time_entry_time_format, inclusion: { in: %w[minutes hours] }
+end

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -64,9 +64,37 @@
         </div>
       </div>
 
-      <div class="flex gap-2 flex-col tour--logged-time">
-        <%= f.label :total_logged_time_in_minutes, "*"+ TimeEntry.human_attribute_name(:total_logged_time_in_minutes), class: "label-primary" %>
-        <%= f.number_field :total_logged_time_in_minutes, required: true, class: "input-primary" %>
+      <div class="flex gap-2 flex-col tour--logged-time" data-controller="time-entry--time-input-formatter" data-time-entry--time-input-formatter-format-value="<%= current_user.preferences.time_entry_time_format %>">
+        <div class="flex justify-between items-center">
+          <%= f.label :total_logged_time_in_minutes, "*" + TimeEntry.human_attribute_name(:total_logged_time), class: "label-primary" %>
+
+          <div class="flex gap-2 items-center">
+            <button type="button"
+                    data-time-entry--time-input-formatter-target="tab"
+                    data-format="minutes"
+                    data-action="click->time-entry--time-input-formatter#selectFormat"
+                    class="tab-item tab-item-xs <%= current_user.preferences.time_entry_time_format == 'minutes' ? 'tab-item--active' : '' %>">
+              <%= t('minutes') %>
+            </button>
+            <button type="button"
+                    data-time-entry--time-input-formatter-target="tab"
+                    data-format="hours"
+                    data-action="click->time-entry--time-input-formatter#selectFormat"
+                    class="tab-item tab-item-xs <%= current_user.preferences.time_entry_time_format == 'hours' ? 'tab-item--active' : '' %>">
+              <%= t('hours') %>
+            </button>
+          </div>
+        </div>
+
+        <%= f.hidden_field :total_logged_time_in_minutes,
+            data: {
+              'time-entry--time-input-formatter-target': "input"
+            } %>
+
+        <input type="text"
+          class="input-primary cpy-input-placeholder"
+          value="<%= time_entry.total_logged_time_in_minutes %>" data-time-entry--time-input-formatter-target="placeholder"/>
+
       </div>
 
       <div class="flex gap-2 justify-center mt-2 tour--form-actions">

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -92,6 +92,7 @@
             } %>
 
         <input type="text"
+          id="time_entry_total_logged_time"
           class="input-primary cpy-input-placeholder"
           value="<%= time_entry.total_logged_time_in_minutes %>" data-time-entry--time-input-formatter-target="placeholder"/>
 

--- a/app/views/time_entries/_form.html.erb
+++ b/app/views/time_entries/_form.html.erb
@@ -69,20 +69,20 @@
           <%= f.label :total_logged_time_in_minutes, "*" + TimeEntry.human_attribute_name(:total_logged_time), class: "label-primary" %>
 
           <div class="flex gap-2 items-center">
-            <button type="button"
+            <a href="<%= update_preferences_profile_path(time_entry_time_format: 'minutes') %>" data-turbo-method="patch"
                     data-time-entry--time-input-formatter-target="tab"
                     data-format="minutes"
                     data-action="click->time-entry--time-input-formatter#selectFormat"
                     class="tab-item tab-item-xs <%= current_user.preferences.time_entry_time_format == 'minutes' ? 'tab-item--active' : '' %>">
               <%= t('minutes') %>
-            </button>
-            <button type="button"
+            </a>
+            <a href="<%= update_preferences_profile_path(time_entry_time_format: 'hours') %>" data-turbo-method="patch"
                     data-time-entry--time-input-formatter-target="tab"
                     data-format="hours"
                     data-action="click->time-entry--time-input-formatter#selectFormat"
                     class="tab-item tab-item-xs <%= current_user.preferences.time_entry_time_format == 'hours' ? 'tab-item--active' : '' %>">
               <%= t('hours') %>
-            </button>
+            </a>
           </div>
         </div>
 

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -71,6 +71,7 @@ en:
         issue_id: 'Issue'
         issue: 'Issue'
         project: 'Project'
+        total_logged_time: 'Logged time'
         total_logged_time_in_minutes: 'Logged time (minutes)'
         reference_date: 'Date'
 

--- a/config/locales/activerecord.pt-BR.yml
+++ b/config/locales/activerecord.pt-BR.yml
@@ -71,6 +71,7 @@ pt-BR:
         project: 'Projeto'
         issue_id: 'Issue'
         issue: 'Issue'
+        total_logged_time: 'Tempo registrado'
         total_logged_time_in_minutes: 'Tempo registrado (minutos)'
         reference_date: 'Data'
       visualization:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -95,7 +95,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resource :profile, only: [ :edit, :update ]
+  resource :profile, only: [ :edit, :update ] do
+    patch :update_preferences
+  end
 
   resources :notifications, only: [] do
     member do

--- a/db/migrate/20250805210945_create_user_preferences.rb
+++ b/db/migrate/20250805210945_create_user_preferences.rb
@@ -1,0 +1,8 @@
+class CreateUserPreferences < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_preferences do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :time_entry_time_format, null: false, default: "minutes"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_29_171219) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_05_210945) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -114,16 +114,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_29_171219) do
     t.index ["project_id"], name: "index_issues_on_project_id"
   end
 
-  create_table "notes", force: :cascade do |t|
-    t.string "title"
-    t.text "description"
-    t.string "notable_type", null: false
-    t.integer "notable_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["notable_type", "notable_id"], name: "index_notes_on_notable"
-  end
-
   create_table "notifications", force: :cascade do |t|
     t.string "title", null: false
     t.text "content"
@@ -159,6 +149,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_29_171219) do
     t.index ["user_id"], name: "index_time_entries_on_user_id"
   end
 
+  create_table "user_preferences", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "time_entry_time_format", default: "minutes", null: false
+    t.index ["user_id"], name: "index_user_preferences_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "locale", limit: 5
     t.string "timezone"
@@ -188,5 +184,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_29_171219) do
   add_foreign_key "issues", "projects"
   add_foreign_key "time_entries", "projects"
   add_foreign_key "time_entries", "users"
+  add_foreign_key "user_preferences", "users"
   add_foreign_key "visualizations", "projects"
 end

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe ProfilesController do
+  describe 'PATCH #update_preferences' do
+    specify 'Updating the time entry time format' do
+      user = Current.user
+      user.preferences.time_entry_time_format = 'minutes'
+      user.save!
+
+      patch :update_preferences, params: { time_entry_time_format: 'hours' }
+
+      user.reload
+      expect(user.preferences.time_entry_time_format).to eq('hours')
+    end
+  end
+end

--- a/spec/features/time_entries/custom_time_format_spec.rb
+++ b/spec/features/time_entries/custom_time_format_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe 'Time entry - custom time format input' do
+  let!(:user) { FactoryBot.create(:user) }
+  let!(:project) { FactoryBot.create(:project) }
+
+  around(:example) do |ex|
+    Timecop.freeze("2023-07-13 12:00".to_datetime) do
+      ex.run
+    end
+  end
+
+  specify "I can switch between different time formats" do
+    user.preferences.time_entry_time_format = 'minutes'
+    user.save!
+
+    time_entry = FactoryBot.create(:time_entry, user:, total_logged_time_in_minutes: 110, description: 'td entry2', reference_date: Date.current)
+
+    visit time_entries_path
+
+    within "#time_entry_#{time_entry.id}" do
+      click_link "Edit"
+    end
+
+    within '#time_entry_form' do
+      expect(first('.cpy-input-placeholder').value).to eq('110')
+      click_button('Hours')
+      expect(first('.cpy-input-placeholder').value).to eq('1.83')
+    end
+  end
+end

--- a/spec/features/time_entries/custom_time_format_spec.rb
+++ b/spec/features/time_entries/custom_time_format_spec.rb
@@ -24,8 +24,16 @@ describe 'Time entry - custom time format input' do
 
     within '#time_entry_form' do
       expect(first('.cpy-input-placeholder').value).to eq('110')
-      click_button('Hours')
+
+      click_link('Hours')
       expect(first('.cpy-input-placeholder').value).to eq('1.83')
+      user.reload
+      expect(user.preferences.time_entry_time_format).to eq('hours')
+
+      click_link('Minutes')
+      expect(first('.cpy-input-placeholder').value).to eq('110')
+      user.reload
+      expect(user.preferences.time_entry_time_format).to eq('minutes')
     end
   end
 end

--- a/spec/features/time_entries/custom_time_format_spec.rb
+++ b/spec/features/time_entries/custom_time_format_spec.rb
@@ -27,13 +27,37 @@ describe 'Time entry - custom time format input' do
 
       click_link('Hours')
       expect(first('.cpy-input-placeholder').value).to eq('1.83')
-      user.reload
+      user.preferences.reload
       expect(user.preferences.time_entry_time_format).to eq('hours')
 
       click_link('Minutes')
       expect(first('.cpy-input-placeholder').value).to eq('110')
-      user.reload
+      user.preferences.reload
       expect(user.preferences.time_entry_time_format).to eq('minutes')
     end
+  end
+
+  specify "I can update the time entry with the new format" do
+    user.preferences.time_entry_time_format = 'minutes'
+    user.save!
+
+    time_entry = FactoryBot.create(:time_entry, user:, total_logged_time_in_minutes: 110, description: 'td entry2', reference_date: Date.current)
+
+    visit time_entries_path
+
+    within "#time_entry_#{time_entry.id}" do
+      click_link "Edit"
+    end
+
+    within '#time_entry_form' do
+      click_link('Hours')
+      fill_in 'time_entry_total_logged_time', with: '2.3'
+      click_button 'Update'
+    end
+
+    expect(page).to have_content('Time entry was successfully updated.')
+
+    time_entry.reload
+    expect(time_entry.total_logged_time_in_minutes).to eq(138)
   end
 end

--- a/spec/features/time_entries/managing_time_entries_from_time_workspace_spec.rb
+++ b/spec/features/time_entries/managing_time_entries_from_time_workspace_spec.rb
@@ -56,7 +56,7 @@ context "As a user, I want to manage my time entries" do
     first(:link, "New time entry").click
 
     fill_in :time_entry_description, with: "new description"
-    fill_in :time_entry_total_logged_time_in_minutes, with: "20"
+    fill_in :time_entry_total_logged_time, with: "20"
     select_from_select2(label_for: 'time_entry_project_id', option_text: "One project")
     select_from_select2(selector: '#project_dependent_fields .select2', option_text: "Special issue")
 
@@ -84,7 +84,7 @@ context "As a user, I want to manage my time entries" do
     end
 
     fill_in :time_entry_description, with: "Edited description"
-    fill_in :time_entry_total_logged_time_in_minutes, with: "45"
+    fill_in :time_entry_total_logged_time, with: "45"
     select_from_select2(label_for: 'time_entry_project_id', option_text: "New project")
     select_from_select2(selector: '#project_dependent_fields .select2', option_text: "New issue")
 
@@ -111,7 +111,7 @@ context "As a user, I want to manage my time entries" do
     end
 
     fill_in :time_entry_description, with: "Edited description"
-    fill_in :time_entry_total_logged_time_in_minutes, with: "45"
+    fill_in :time_entry_total_logged_time, with: "45"
     select_from_select2(label_for: 'time_entry_project_id', option_text: "New project")
     select_from_select2(selector: '#project_dependent_fields .select2', option_text: "New issue")
 

--- a/spec/models/user/preferences_spec.rb
+++ b/spec/models/user/preferences_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe User::Preferences do
+  describe '#time_entry_time_format' do
+    it 'has a minutes format by default' do
+      user = User.new
+      expect(user.preferences.time_entry_time_format).to eq('minutes')
+    end
+
+    it 'can be set to hours' do
+      user = create(:user)
+      user.preferences.time_entry_time_format = 'hours'
+      user.save!
+      user.reload
+      expect(user.preferences.time_entry_time_format).to eq('hours')
+    end
+  end
+end


### PR DESCRIPTION
This allows the user to input the 'total logged time' for a time entry in hours or minutes. 
The user can select their favorite input method (minutes or hours) 

![time-entry-input-format-2](https://github.com/user-attachments/assets/cf6ed142-c904-4d3a-8b2c-0661f7b2e4e8)

# Changes

- Created a user_preferences table with time_entry_time_format column. (
- Added a `tab.css` component (useful for the future layout/components refactoring) 
- Created a update_preferences generic endpoint on ProfilesController 
- Changed the Time Entry form to have a placeholder input showing the value in minutes or hours while the real 'total logged time in minutes' remains hidden. 

# Future changes
- The "favorite_theme" can be moved to the user_preferences in a future PR