### PR TITLE
ref: changes draggable card element to be <a> instead of <li>

### DIFF
--- a/app/views/visualizations/_card.html.erb
+++ b/app/views/visualizations/_card.html.erb
@@ -1,17 +1,16 @@
-<li class="cpy-card tour--card issue--card show-issue-finish-toggle-on-hover"
+<a class="cpy-card tour--card issue--card show-issue-finish-toggle-on-hover"
   id="<%= dom_id(issue) %>"
+  href="<%= show_visualization_issue_path(visualization, issue) %>"
   data-controller="visualization--board--card"
   data-favorite-issue-labels-issue-id="<%= issue.id %>"
   data-visualization--board--card-scroll-on-connect-value="<%= local_assigns[:scroll_on_connect] == true %>"
   data-grouping-column-target="card"
   data-grouping-column-issue-id-value="<%= issue.id %>"
-  data-visualization--issue-filtering-target="issue">
-  <%= link_to show_visualization_issue_path(visualization, issue),
-    class: "group relative flex flex-col gap-2 text-sm text-content-500 border-2 border-background-200 bg-background-50 hover:bg-background-100 hover:border-background-900 cursor-pointer shadow-sm rounded-xl card p-3",
-    data: {
-      turbo_frame: 'issue_detail',
-      turbo_action: 'advance'
-    } do %>
+  data-visualization--issue-filtering-target="issue"
+  data-turbo-frame="issue_detail"
+  data-turbo-action="advance"
+  >
+  <div class="group relative flex flex-col gap-2 text-sm text-content-500 border-2 border-background-200 bg-background-50 hover:bg-background-100 hover:border-background-900 cursor-pointer shadow-sm rounded-xl card p-3">
 
     <div class="hidden flex items-center justify-center p-2 text-xs flex group-hover:flex items-center absolute top-2 right-2 rounded-full  bg-background-50">
       <i class="fa fa-pencil"></i>
@@ -32,5 +31,5 @@
     <%= render partial: 'visualizations/groupings/_card/icons', locals: { issue: } %>
 
     <%= due_date_for(issue) %>
-  <% end %>
-</li>
+  </div>
+</a>

--- a/app/views/visualizations/_column.html.erb
+++ b/app/views/visualizations/_column.html.erb
@@ -94,7 +94,7 @@
     </div>
   </header>
 
-  <ul
+  <div
     id="<%= grouping.id %>-cards-wrapper"
     class="board--column--card-list js-no-column-drag cpy-drop-zone"
     data-controller="sortable"
@@ -114,7 +114,7 @@
         } %>
       <% end %>
     <% end %>
-  </ul>
+  </div>
 
   <div class="board--column--footer">
     <%= render partial: 'visualizations/_column/inline_card_form', locals: { grouping:, visualization: } %>


### PR DESCRIPTION
This PR fixes the card Drag/Drop on Vivaldi browser as reported on https://github.com/Eigenfocus/eigenfocus/issues/273 

# Cause
The old HTML structure with a  draggable `li` containing an `a` inside was causing the bug (probably because the link was capturing the mouse down event). As explained in the issue, this error doesn't happen with the new implementation using React in the PRO Edition so it's not worth spending too much time checking it. 

# Solution
I've changed the card list structure to be `a div > a.card` instead of `ul > li.card > a` so the `a` is the draggable element

# OBS
The same error happens if we try to drag/drop a column. But in this case we still can execute the action by start the drag on the top-left corner of the column. 