### PR TITLE
Revert "build(deps): bump puma from 6.6.1 to 7.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,7 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (7.0.0)
+    puma (6.6.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)


### PR DESCRIPTION
Reverts Eigenfocus/eigenfocus#272

Waiting for the solid_queue update: https://github.com/rails/solid_queue/issues/633