### PR TITLE
chore: changes modal backdrop to close on mousedown instead of click

### DIFF
--- a/app/helpers/application_helper/modal.rb
+++ b/app/helpers/application_helper/modal.rb
@@ -12,7 +12,7 @@ module Modal
       data: {
         'modal-target': "container",
         'modal-allow-background-close': true,
-        'action': "click->modal#closeBackground keyup@window->modal#closeWithKeyboard"
+        'action': "mousedown->modal#closeBackground keyup@window->modal#closeWithKeyboard"
       },
       class: "animate__animated animate__fadeIn fixed inset-0 overflow-y-auto flex items-center justify-center",
       style: "z-index: 9999; animation-duration: 300ms;"


### PR DESCRIPTION
# Why
As reported on https://github.com/Eigenfocus/eigenfocus/issues/283

If we start our click inside a modal and move the mouse to the outside and release our click, it will be computed as if the user clicked on the outside of the modal. 

This lead to situations where we try to select a text (inside a modal) and if we move our mouse too fast and finish our "mouseup" outside of it, the modal closes. 

# Solution
Just changed modal container "click" event to "mousedown". 

It feels a bit odd that the modal closes on the "mousedown" when we purposely click on the outside but this is the most viable solution right now. 

Trying to make things work using click would require a bigger refactoring changing the modal container and background z-index's and HTML placement.