### PR TITLE
chore: fix flaky time input preference specs

### DIFF
--- a/spec/features/time_entries/custom_time_format_spec.rb
+++ b/spec/features/time_entries/custom_time_format_spec.rb
@@ -27,17 +27,18 @@ describe 'Time entry - custom time format input' do
 
       click_link('Hours')
       expect(first('.cpy-input-placeholder').value).to eq('1.83')
+
+      wait_for_turbo_frame_response
       user.preferences.reload
       expect(user.preferences.time_entry_time_format).to eq('hours')
 
       click_link('Minutes')
       expect(first('.cpy-input-placeholder').value).to eq('110')
 
-      click_button 'Update'
+      wait_for_turbo_frame_response
+      user.preferences.reload
+      expect(user.preferences.time_entry_time_format).to eq('minutes')
     end
-    expect(page).to have_content('Time entry was successfully updated.')
-    user.preferences.reload
-    expect(user.preferences.time_entry_time_format).to eq('minutes')
   end
 
   specify "I can update the time entry with the new format" do

--- a/spec/support/helpers/wait_for_ajax_responses.rb
+++ b/spec/support/helpers/wait_for_ajax_responses.rb
@@ -1,0 +1,9 @@
+module WaitForAjaxResponsesRspecHelper
+  def wait_for_turbo_frame_response
+    expect(page).to_not have_selector("[busy]")
+  end
+end
+
+RSpec.configure do |config|
+  config.include WaitForAjaxResponsesRspecHelper, type: :feature
+end


### PR DESCRIPTION
The specs were flaky because the assertion that was checking if the database was updated was being made before the request/update was completed.

I've added a helper to wait for the turbo frame response to complete, by checking the presence of the turbo-frame[busy] attribute (https://turbo.hotwired.dev/handbook/frames#eager-loading-frames)