### PR TITLE
Revert "Fix modal open animation"

### DIFF
--- a/app/components/modal/dialog_component.html.erb
+++ b/app/components/modal/dialog_component.html.erb
@@ -1,9 +1,8 @@
 <%= content_tag(:dialog, {
-    # We pass the open value to the modal controller so we can open it programmatically
-    # when the element is inserted in the DOM so the show animation is triggered
-    data: { controller: "modal", "modal-open-value": open } ,
+    data: { controller: "modal"} ,
     id: dialog_id,
-    class: "modal"
+    class: "modal",
+    open: open,
   }) do %>
   <%= content_tag(:div, modal_box) do %>
     <% unless hide_close_button? %>

--- a/app/components/modal/dialog_component.rb
+++ b/app/components/modal/dialog_component.rb
@@ -9,7 +9,7 @@ class Modal::DialogComponent < ViewComponent::Base
     @title = title
     @icon = icon
     @modal_box = modal_box
-    modal_box[:class] = modal_box[:class].to_s + " modal-box max-h-[95vh]"
+    modal_box[:class] = modal_box[:class].to_s + " modal-box"
     @open = open
     @dialog_id = dialog_id
     @hide_close_button = hide_close_button

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -10,15 +10,8 @@ import {
 } from "tailwindcss-stimulus-components"
 
 class CustomModal extends Modal {
-  static values = {
-    open: Boolean
-  }
-
   connect() {
     if (this.isDialog) {
-      if (this.openValue) {
-        this.open()
-      }
       return
     }
 
@@ -37,10 +30,6 @@ class CustomModal extends Modal {
       this.background = document.querySelector(`#${this.backgroundId}`);
       this.background.style.backgroundColor = "rgba(0, 0, 0, 0.35)"
     }
-  }
-
-  open() {
-    this.element.showModal()
   }
 
   close(e) {

--- a/app/views/issues/_issue_detail.html.erb
+++ b/app/views/issues/_issue_detail.html.erb
@@ -14,7 +14,7 @@
   <%= render Modal::DialogComponent.new(
     hide_close_button: true,
     modal_box: {
-      class: "max-w-5xl relative cpy-issue-detail p-0 flex flex-col",
+      class: "max-w-5xl relative cpy-issue-detail max-h-[95vh] p-0 flex flex-col",
       data: data,
     }) do %>
 


### PR DESCRIPTION
This reverts commit 16be876c97ced0e84f1c945d78bbbf594c83d1b1.

It introduced a bug that select2 doesn't open properly inside modals.
